### PR TITLE
Refactor MainActivity setup/tuning logic into MainActivitySetup.kt

### DIFF
--- a/app/src/main/java/com/yogaflow/MainActivity.kt
+++ b/app/src/main/java/com/yogaflow/MainActivity.kt
@@ -91,10 +91,10 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
     private val stateMachine = PoseStateMachine()
     internal val flowEngine = PoseFlowEngine()
     internal val playlist = FlowPlaylistEngine()
-    private val runtimeOverrideStore = RuntimeOverrideStore()
+    internal val runtimeOverrideStore = RuntimeOverrideStore()
     private val autoTuningAdvisor = AutoTuningAdvisor()
     internal var latestSuggestion: AutoTuningSuggestion? = null
-    private var suppressTuningCallbacks = false
+    internal var suppressTuningCallbacks = false
 
     internal lateinit var currentFlow: YogaFlow
     internal lateinit var currentPose: YogaPose
@@ -140,77 +140,21 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         }
     }
 
-    private fun bindViews() {
-        homeView = findViewById(R.id.homeView)
-        classView = findViewById(R.id.classView)
-        previewView = findViewById(R.id.previewView)
-        overlayView = findViewById(R.id.overlayView)
-        cameraSetupPanel = findViewById(R.id.cameraSetupPanel)
-        cameraSetupStatus = findViewById(R.id.cameraSetupStatus)
-        debugText = findViewById(R.id.debugText)
-        coachText = findViewById(R.id.coachText)
-        flowName = findViewById(R.id.flowName)
-        progressText = findViewById(R.id.progressText)
-        countdownText = findViewById(R.id.countdownText)
-        llmStatus = findViewById(R.id.llmStatus)
-        progressBar = findViewById(R.id.progressBar)
-        squatThresholdLabel = findViewById(R.id.squatThresholdLabel)
-        bridgeThresholdLabel = findViewById(R.id.bridgeThresholdLabel)
-        squatThresholdSeekBar = findViewById(R.id.squatThresholdSeekBar)
-        bridgeThresholdSeekBar = findViewById(R.id.bridgeThresholdSeekBar)
-        startClassButton = findViewById(R.id.startClassButton)
-        startStretchButton = findViewById(R.id.startStretchButton)
-        startRecoveryButton = findViewById(R.id.startRecoveryButton)
-        startButton = findViewById(R.id.startButton)
-        pauseButton = findViewById(R.id.pauseButton)
-        restartButton = findViewById(R.id.restartButton)
-    }
 
-    private fun setupThresholdControls() {
-        squatThresholdSeekBar.max = TUNING_SLIDER_MAX
-        bridgeThresholdSeekBar.max = TUNING_SLIDER_MAX
-        squatThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListener(0))
-        bridgeThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListener(1))
-        updateRuntimeTuningControls()
-    }
+    private fun bindViews() = bindViewsImpl()
 
-    private fun runtimeTuningListener(index: Int): SeekBar.OnSeekBarChangeListener {
-        return object : SeekBar.OnSeekBarChangeListener {
-            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                if (!fromUser || suppressTuningCallbacks) return
-                val binding = computeCurrentTuningBindings().getOrNull(index) ?: return
-                val value = sliderProgressToValue(progress, binding.param, TUNING_SLIDER_MAX)
-                runtimeOverrideStore.set(binding.key, value)
-                updateRuntimeTuningControls()
-            }
-            override fun onStartTrackingTouch(seekBar: SeekBar?) = Unit
-            override fun onStopTrackingTouch(seekBar: SeekBar?) = Unit
-        }
-    }
+    private fun setupThresholdControls() = setupThresholdControlsImpl()
 
-    private fun loadThresholdPreferences() {
-        val prefs = getSharedPreferences(THRESHOLD_PREFS, MODE_PRIVATE)
-        val squat = prefs.getFloat(KEY_SQUAT_HOLD_KNEE_MAX, ThresholdConfig.squatHoldKneeMaxDegrees.toFloat()).toDouble()
-        val bridge = prefs.getFloat(KEY_BRIDGE_LIFT_HIP_MAX, ThresholdConfig.bridgeLiftHipMaxDegrees.toFloat()).toDouble()
-        ThresholdConfig.squatHoldKneeMaxDegrees = clampThreshold(squat, SQUAT_THRESHOLD_MIN, SQUAT_THRESHOLD_RANGE)
-        ThresholdConfig.bridgeLiftHipMaxDegrees = clampThreshold(bridge, BRIDGE_THRESHOLD_MIN, BRIDGE_THRESHOLD_RANGE)
-    }
+    internal fun runtimeTuningListener(index: Int): SeekBar.OnSeekBarChangeListener = runtimeTuningListenerImpl(index)
 
-    private fun saveThresholdPreferences() {
-        getSharedPreferences(THRESHOLD_PREFS, MODE_PRIVATE)
-            .edit()
-            .putFloat(KEY_SQUAT_HOLD_KNEE_MAX, ThresholdConfig.squatHoldKneeMaxDegrees.toFloat())
-            .putFloat(KEY_BRIDGE_LIFT_HIP_MAX, ThresholdConfig.bridgeLiftHipMaxDegrees.toFloat())
-            .apply()
-    }
+    private fun loadThresholdPreferences() = loadThresholdPreferencesImpl()
 
-    private fun thresholdProgress(value: Double, min: Double, maxProgress: Int): Int {
-        return (value - min).toInt().coerceIn(0, maxProgress)
-    }
+    internal fun saveThresholdPreferences() = saveThresholdPreferencesImpl()
 
-    private fun clampThreshold(value: Double, min: Double, range: Int): Double {
-        return value.coerceIn(min, min + range)
-    }
+    internal fun thresholdProgress(value: Double, min: Double, maxProgress: Int): Int = thresholdProgressImpl(value, min, maxProgress)
+
+    internal fun clampThreshold(value: Double, min: Double, range: Int): Double = clampThresholdImpl(value, min, range)
+
 
     private fun initRuntime() {
         loadDiscoveredPlaylist(openClassView = false)

--- a/app/src/main/java/com/yogaflow/MainActivitySetup.kt
+++ b/app/src/main/java/com/yogaflow/MainActivitySetup.kt
@@ -1,0 +1,77 @@
+package com.yogaflow
+
+import android.widget.SeekBar
+import com.yogaflow.coach.ThresholdConfig
+
+internal fun MainActivity.bindViewsImpl() {
+    homeView = findViewById(R.id.homeView)
+    classView = findViewById(R.id.classView)
+    previewView = findViewById(R.id.previewView)
+    overlayView = findViewById(R.id.overlayView)
+    cameraSetupPanel = findViewById(R.id.cameraSetupPanel)
+    cameraSetupStatus = findViewById(R.id.cameraSetupStatus)
+    debugText = findViewById(R.id.debugText)
+    coachText = findViewById(R.id.coachText)
+    flowName = findViewById(R.id.flowName)
+    progressText = findViewById(R.id.progressText)
+    countdownText = findViewById(R.id.countdownText)
+    llmStatus = findViewById(R.id.llmStatus)
+    progressBar = findViewById(R.id.progressBar)
+    squatThresholdLabel = findViewById(R.id.squatThresholdLabel)
+    bridgeThresholdLabel = findViewById(R.id.bridgeThresholdLabel)
+    squatThresholdSeekBar = findViewById(R.id.squatThresholdSeekBar)
+    bridgeThresholdSeekBar = findViewById(R.id.bridgeThresholdSeekBar)
+    startClassButton = findViewById(R.id.startClassButton)
+    startStretchButton = findViewById(R.id.startStretchButton)
+    startRecoveryButton = findViewById(R.id.startRecoveryButton)
+    startButton = findViewById(R.id.startButton)
+    pauseButton = findViewById(R.id.pauseButton)
+    restartButton = findViewById(R.id.restartButton)
+}
+
+internal fun MainActivity.setupThresholdControlsImpl() {
+    squatThresholdSeekBar.max = MainActivity.TUNING_SLIDER_MAX
+    bridgeThresholdSeekBar.max = MainActivity.TUNING_SLIDER_MAX
+    squatThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListener(0))
+    bridgeThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListener(1))
+    updateRuntimeTuningControls()
+}
+
+internal fun MainActivity.runtimeTuningListenerImpl(index: Int): SeekBar.OnSeekBarChangeListener {
+    return object : SeekBar.OnSeekBarChangeListener {
+        override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+            if (!fromUser || suppressTuningCallbacks) return
+            val binding = computeCurrentTuningBindings().getOrNull(index) ?: return
+            val value = sliderProgressToValue(progress, binding.param, MainActivity.TUNING_SLIDER_MAX)
+            runtimeOverrideStore.set(binding.key, value)
+            updateRuntimeTuningControls()
+        }
+
+        override fun onStartTrackingTouch(seekBar: SeekBar?) = Unit
+        override fun onStopTrackingTouch(seekBar: SeekBar?) = Unit
+    }
+}
+
+internal fun MainActivity.loadThresholdPreferencesImpl() {
+    val prefs = getSharedPreferences("threshold_prefs", MODE_PRIVATE)
+    val squat = prefs.getFloat("squat_hold_knee_max", ThresholdConfig.squatHoldKneeMaxDegrees.toFloat()).toDouble()
+    val bridge = prefs.getFloat("bridge_lift_hip_max", ThresholdConfig.bridgeLiftHipMaxDegrees.toFloat()).toDouble()
+    ThresholdConfig.squatHoldKneeMaxDegrees = clampThreshold(squat, 80.0, 70)
+    ThresholdConfig.bridgeLiftHipMaxDegrees = clampThreshold(bridge, 120.0, 70)
+}
+
+internal fun MainActivity.saveThresholdPreferencesImpl() {
+    getSharedPreferences("threshold_prefs", MODE_PRIVATE)
+        .edit()
+        .putFloat("squat_hold_knee_max", ThresholdConfig.squatHoldKneeMaxDegrees.toFloat())
+        .putFloat("bridge_lift_hip_max", ThresholdConfig.bridgeLiftHipMaxDegrees.toFloat())
+        .apply()
+}
+
+internal fun MainActivity.thresholdProgressImpl(value: Double, min: Double, maxProgress: Int): Int {
+    return (value - min).toInt().coerceIn(0, maxProgress)
+}
+
+internal fun MainActivity.clampThresholdImpl(value: Double, min: Double, range: Int): Double {
+    return value.coerceIn(min, min + range)
+}


### PR DESCRIPTION
### Motivation
- Reduce the size and complexity of `MainActivity.kt` by moving view-binding and runtime tuning helpers into a focused extension file to improve readability and maintainability.
- Allow the setup and tuning logic to be maintained independently while preserving the original activity lifecycle and call sites.
- Enable the extracted helpers to access necessary members by adjusting visibility where required.

### Description
- Added a new extension file `app/src/main/java/com/yogaflow/MainActivitySetup.kt` that implements view binding, slider wiring, and threshold preference helpers as `*Impl` functions (e.g. `bindViewsImpl`, `setupThresholdControlsImpl`).
- Updated `MainActivity.kt` to delegate the original setup/tuning methods to the new impl functions (e.g. `bindViews()` -> `bindViewsImpl()`), preserving existing method names and `onCreate` flow.
- Changed visibility of `runtimeOverrideStore` and `suppressTuningCallbacks` from `private` to `internal` so the new extension helpers can access them.
- Kept behavior and public/internal APIs intact; no changes to UI flow or high-level logic were introduced beyond delegating to the extracted helpers.

### Testing
- Attempted to run `./gradlew :app:compileDebugKotlin`, but the repository root does not include a `gradlew` wrapper, so the compile step could not be executed in this environment (build not run).
- Verified code changes by committing the new file and updated `MainActivity.kt` locally; no automated tests were executed beyond the attempted compile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f8b3a9f8832f9d7f86417b15a7d9)