### PR TITLE
Refactor MainActivity setup helpers and remove redundant wrappers

### DIFF
--- a/app/src/main/java/com/yogaflow/MainActivity.kt
+++ b/app/src/main/java/com/yogaflow/MainActivity.kt
@@ -1,11 +1,9 @@
 package com.yogaflow
 
-import android.animation.ObjectAnimator
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.view.View
-import android.view.animation.DecelerateInterpolator
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.SeekBar
@@ -13,41 +11,22 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
-import com.yogaflow.coach.BridgeDetectionMapper
 import com.yogaflow.coach.CoachCueController
 import com.yogaflow.coach.CoachSpeaker
-import com.yogaflow.coach.CoachState
-import com.yogaflow.coach.ForwardFoldDetectionMapper
 import com.yogaflow.coach.PoseFlowEngine
 import com.yogaflow.coach.PoseStateMachine
-import com.yogaflow.coach.SquatDetectionMapper
-import com.yogaflow.coach.ThresholdConfig
-import com.yogaflow.coach.TwistDetectionMapper
 import com.yogaflow.flow.AutoTuningAdvisor
 import com.yogaflow.flow.AutoTuningSuggestion
-import com.yogaflow.flow.FlowLoader
 import com.yogaflow.flow.FlowPlaylistEngine
-import com.yogaflow.flow.RuntimeOverrideKey
 import com.yogaflow.flow.RuntimeOverrideStore
-import com.yogaflow.flow.RuntimeParams
-import com.yogaflow.flow.TunableRuntimeParam
-import com.yogaflow.flow.TunableRuntimeParamExtractor
 import com.yogaflow.flow.YogaFlow
 import com.yogaflow.llm.LlmCoach
-import com.yogaflow.pose.CameraFramingCoach
-import com.yogaflow.pose.CameraFramingStatus
 import com.yogaflow.pose.CameraPosePipeline
-import com.yogaflow.pose.DebugPoseInfo
 import com.yogaflow.pose.PoseDetectionResult
-import com.yogaflow.pose.PoseGeometry
 import com.yogaflow.pose.PoseHelper
 import com.yogaflow.pose.PoseOverlayView
-import com.yogaflow.pose.ViewOrientation
-import com.yogaflow.pose.ViewOrientationStatus
 import com.yogaflow.session.LiveCoachSessionController
 import com.yogaflow.yoga.YogaPose
-import com.yogaflow.yoga.YogaPoseCatalog
-import kotlin.math.abs
 import java.util.Locale
 import java.util.concurrent.Executors
 
@@ -114,10 +93,10 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        bindViews()
-        loadThresholdPreferences()
+        bindViewsMain()
+        loadThresholdPreferencesMain()
         initRuntime()
-        setupThresholdControls()
+        setupThresholdControlsMain()
         setupButtons()
         showHome()
 
@@ -140,21 +119,6 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             coachText.text = "Camera permission is required to start pose coaching."
         }
     }
-
-
-    private fun bindViews() = bindViewsImpl()
-
-    private fun setupThresholdControls() = setupThresholdControlsImpl()
-
-    internal fun runtimeTuningListener(index: Int): SeekBar.OnSeekBarChangeListener = runtimeTuningListenerImpl(index)
-
-    private fun loadThresholdPreferences() = loadThresholdPreferencesImpl()
-
-    internal fun saveThresholdPreferences() = saveThresholdPreferencesImpl()
-
-    internal fun thresholdProgress(value: Double, min: Double, maxProgress: Int): Int = thresholdProgressImpl(value, min, maxProgress)
-
-    internal fun clampThreshold(value: Double, min: Double, range: Int): Double = clampThresholdImpl(value, min, range)
 
 
     private fun initRuntime() {

--- a/app/src/main/java/com/yogaflow/MainActivitySetup.kt
+++ b/app/src/main/java/com/yogaflow/MainActivitySetup.kt
@@ -3,7 +3,7 @@ package com.yogaflow
 import android.widget.SeekBar
 import com.yogaflow.coach.ThresholdConfig
 
-internal fun MainActivity.bindViewsImpl() {
+internal fun MainActivity.bindViewsMain() {
     homeView = findViewById(R.id.homeView)
     classView = findViewById(R.id.classView)
     previewView = findViewById(R.id.previewView)
@@ -29,15 +29,15 @@ internal fun MainActivity.bindViewsImpl() {
     restartButton = findViewById(R.id.restartButton)
 }
 
-internal fun MainActivity.setupThresholdControlsImpl() {
+internal fun MainActivity.setupThresholdControlsMain() {
     squatThresholdSeekBar.max = MainActivity.TUNING_SLIDER_MAX
     bridgeThresholdSeekBar.max = MainActivity.TUNING_SLIDER_MAX
-    squatThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListener(0))
-    bridgeThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListener(1))
+    squatThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListenerMain(0))
+    bridgeThresholdSeekBar.setOnSeekBarChangeListener(runtimeTuningListenerMain(1))
     updateRuntimeTuningControls()
 }
 
-internal fun MainActivity.runtimeTuningListenerImpl(index: Int): SeekBar.OnSeekBarChangeListener {
+internal fun MainActivity.runtimeTuningListenerMain(index: Int): SeekBar.OnSeekBarChangeListener {
     return object : SeekBar.OnSeekBarChangeListener {
         override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
             if (!fromUser || suppressTuningCallbacks) return
@@ -52,15 +52,15 @@ internal fun MainActivity.runtimeTuningListenerImpl(index: Int): SeekBar.OnSeekB
     }
 }
 
-internal fun MainActivity.loadThresholdPreferencesImpl() {
+internal fun MainActivity.loadThresholdPreferencesMain() {
     val prefs = getSharedPreferences("threshold_prefs", MODE_PRIVATE)
     val squat = prefs.getFloat("squat_hold_knee_max", ThresholdConfig.squatHoldKneeMaxDegrees.toFloat()).toDouble()
     val bridge = prefs.getFloat("bridge_lift_hip_max", ThresholdConfig.bridgeLiftHipMaxDegrees.toFloat()).toDouble()
-    ThresholdConfig.squatHoldKneeMaxDegrees = clampThreshold(squat, 80.0, 70)
-    ThresholdConfig.bridgeLiftHipMaxDegrees = clampThreshold(bridge, 120.0, 70)
+    ThresholdConfig.squatHoldKneeMaxDegrees = clampThresholdMain(squat, 80.0, 70)
+    ThresholdConfig.bridgeLiftHipMaxDegrees = clampThresholdMain(bridge, 120.0, 70)
 }
 
-internal fun MainActivity.saveThresholdPreferencesImpl() {
+internal fun MainActivity.saveThresholdPreferencesMain() {
     getSharedPreferences("threshold_prefs", MODE_PRIVATE)
         .edit()
         .putFloat("squat_hold_knee_max", ThresholdConfig.squatHoldKneeMaxDegrees.toFloat())
@@ -68,10 +68,10 @@ internal fun MainActivity.saveThresholdPreferencesImpl() {
         .apply()
 }
 
-internal fun MainActivity.thresholdProgressImpl(value: Double, min: Double, maxProgress: Int): Int {
+internal fun MainActivity.thresholdProgressMain(value: Double, min: Double, maxProgress: Int): Int {
     return (value - min).toInt().coerceIn(0, maxProgress)
 }
 
-internal fun MainActivity.clampThresholdImpl(value: Double, min: Double, range: Int): Double {
+internal fun MainActivity.clampThresholdMain(value: Double, min: Double, range: Int): Double {
     return value.coerceIn(min, min + range)
 }


### PR DESCRIPTION
### Motivation
- Reduce boilerplate and indirection by removing pass-through wrapper methods that only forwarded calls to setup helpers. 
- Centralize view binding and threshold setup responsibilities into the setup extension file to make initialization explicit. 
- Clean up unused imports in `MainActivity.kt` to reduce noise and improve maintainability.

### Description
- Removed redundant wrapper functions in `MainActivity.kt` and updated `onCreate` to call the clearer helper names `bindViewsMain()`, `loadThresholdPreferencesMain()`, and `setupThresholdControlsMain()` directly. 
- Renamed the `*Impl` helpers in `app/src/main/java/com/yogaflow/MainActivitySetup.kt` to `*Main` (for example `bindViewsImpl` -> `bindViewsMain`, `setupThresholdControlsImpl` -> `setupThresholdControlsMain`) and updated internal listener and helper names accordingly (`runtimeTuningListenerMain`, `clampThresholdMain`, etc.). 
- Updated all internal call sites to use the new function names and adjusted SeekBar listener wiring (`runtimeTuningListenerMain(0/1)`). 
- Removed several unused imports from `MainActivity.kt` to keep the file focused on runtime initialization logic.

### Testing
- Attempted to compile the Kotlin sources with `gradle -q :app:compileDebugKotlin`, but the build could not complete because the Android SDK is not configured in this environment (missing `ANDROID_HOME` or `local.properties` with `sdk.dir`). 
- Verified code references and updated call sites using project search to confirm no remaining usages of the removed wrapper names; the rename and wiring updates were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f704c4b884832f948819c5f3b33802)