### PR TITLE
Refactor: make CameraSetupController single source of truth for readiness

### DIFF
--- a/app/src/main/java/com/yogaflow/session/CameraSetupController.kt
+++ b/app/src/main/java/com/yogaflow/session/CameraSetupController.kt
@@ -14,36 +14,40 @@ class CameraSetupController(
     private val autoStartStableMs: Long,
     private val getSessionState: () -> SessionState,
     private val onReadyChanged: (ready: Boolean, readySince: Long, autoStarted: Boolean) -> Unit,
-    private val getCameraReady: () -> Boolean,
-    private val getCameraReadySince: () -> Long,
-    private val getAutoStarted: () -> Boolean,
     private val setSetupPanelVisible: (Boolean) -> Unit,
     private val onUpdateSetupPanel: (ready: Boolean, framingMessage: String, orientationMessage: String) -> Unit,
-    private val onMaybeAutoStart: () -> Unit,
+    private val onAutoStartReady: () -> Unit,
     private val onSpeakCoachCue: (CoachState, String) -> Unit,
     private val onUpdateDebugOverlay: (frame: PoseDetectionResult, detect: String, state: CoachState, matched: Boolean) -> Unit,
     private val onUpdateUi: (Boolean) -> Unit
 ) {
+    private var ready = false
+    private var readySince = 0L
+    private var autoStarted = false
+
     fun handleFrame(frame: PoseDetectionResult): Boolean {
         val framing = CameraFramingCoach.analyze(frame)
         val orientation = ViewOrientation.analyze(frame)
-        val ready = framing.status == CameraFramingStatus.GOOD && orientation.status == ViewOrientationStatus.GOOD
+        val frameReady = framing.status == CameraFramingStatus.GOOD && orientation.status == ViewOrientationStatus.GOOD
 
         when (getSessionState()) {
             SessionState.IDLE -> {
-                onUpdateSetupPanel(ready, framing.message, orientation.message)
-                onMaybeAutoStart()
-                onUpdateDebugOverlay(frame, "camera_setup", CoachState.SETUP, ready)
+                updateReadyState(frameReady)
+                onUpdateSetupPanel(frameReady, framing.message, orientation.message)
+                maybeAutoStart()
+                onUpdateDebugOverlay(frame, "camera_setup", CoachState.SETUP, frameReady)
                 onUpdateUi(false)
                 return true
             }
             SessionState.PAUSED -> {
+                resetReadyState()
                 setSetupPanelVisible(false)
-                onUpdateDebugOverlay(frame, "paused", CoachState.SETUP, ready)
+                onUpdateDebugOverlay(frame, "paused", CoachState.SETUP, frameReady)
                 onUpdateUi(false)
                 return true
             }
             SessionState.COMPLETED -> {
+                resetReadyState()
                 setSetupPanelVisible(false)
                 onUpdateDebugOverlay(frame, "completed", CoachState.HOLD, true)
                 onUpdateUi(false)
@@ -52,9 +56,10 @@ class CameraSetupController(
             SessionState.RUNNING -> Unit
         }
 
+        resetReadyState()
         setSetupPanelVisible(false)
 
-        if (!ready) {
+        if (!frameReady) {
             val setupCue = cameraSetupCue(framing, orientation)
             onSpeakCoachCue(CoachState.CORRECTION, setupCue)
             onUpdateDebugOverlay(frame, "camera_setup", CoachState.CORRECTION, false)
@@ -63,6 +68,34 @@ class CameraSetupController(
         }
 
         return false
+    }
+
+    private fun updateReadyState(nextReady: Boolean) {
+        val now = System.currentTimeMillis()
+        if (nextReady) {
+            if (!ready) readySince = now
+        } else {
+            readySince = 0L
+            autoStarted = false
+        }
+        ready = nextReady
+        onReadyChanged(ready, readySince, autoStarted)
+    }
+
+    private fun resetReadyState() {
+        if (!ready && readySince == 0L && !autoStarted) return
+        ready = false
+        readySince = 0L
+        autoStarted = false
+        onReadyChanged(ready, readySince, autoStarted)
+    }
+
+    private fun maybeAutoStart() {
+        if (!autoStartEnabled || !ready || autoStarted || readySince == 0L) return
+        if (System.currentTimeMillis() - readySince < autoStartStableMs) return
+        autoStarted = true
+        onReadyChanged(ready, readySince, autoStarted)
+        onAutoStartReady()
     }
 
     private fun cameraSetupCue(


### PR DESCRIPTION
This PR refactors CameraSetupController to fully own camera readiness state.

### Changes
- Move `ready`, `readySince`, and `autoStarted` state into controller
- Remove getter-based state dependencies from MainActivity
- Add internal stability tracking using `autoStartStableMs`
- Trigger auto-start directly from controller via `onAutoStartReady`

### Why
Previously, readiness state was split between MainActivity and CameraSetupController, leading to:
- duplicated logic
- potential race conditions
- unclear ownership of auto-start behavior

This PR establishes CameraSetupController as the single source of truth for setup readiness.

### Scope
- No change to detection logic
- No change to Flow DSL behavior
- Only affects camera setup phase (IDLE state)

### Follow-ups
- Further decouple MainActivity state (SessionState extraction)
- Convert detection mappers from global object to instance-based
- Remove fallback routing in PoseDetectionRouter
