### PR TITLE
Refactor detection mappers to session-owned instances

### DIFF
--- a/app/src/main/java/com/yogaflow/MainActivityPlaylist.kt
+++ b/app/src/main/java/com/yogaflow/MainActivityPlaylist.kt
@@ -1,9 +1,5 @@
 package com.yogaflow
 
-import com.yogaflow.coach.BridgeDetectionMapper
-import com.yogaflow.coach.ForwardFoldDetectionMapper
-import com.yogaflow.coach.SquatDetectionMapper
-import com.yogaflow.coach.TwistDetectionMapper
 import com.yogaflow.flow.FlowLoader
 import com.yogaflow.flow.YogaFlow
 
@@ -39,7 +35,7 @@ internal fun MainActivity.applyPlaylist(flows: List<YogaFlow>, openClassView: Bo
     currentFlow = flow
     currentPose = resolvePose(currentFlow)
     flowEngine.reset()
-    resetDetectionMappers()
+    detectionMapperSession.resetAll()
     latestSuggestion = null
     resetToCameraSetup("請先完成相機設定。")
     llmStatus.text = "LLM: OFF"
@@ -60,7 +56,7 @@ internal fun MainActivity.restartCurrentPlaylist() {
     }
 
     flowEngine.reset()
-    resetDetectionMappers()
+    detectionMapperSession.resetAll()
     latestSuggestion = null
     currentFlow = flow
     currentPose = resolvePose(currentFlow)
@@ -85,9 +81,3 @@ internal fun MainActivity.resetToCameraSetup(message: String) {
     coachText.text = message
 }
 
-internal fun MainActivity.resetDetectionMappers() {
-    ForwardFoldDetectionMapper.reset()
-    TwistDetectionMapper.reset()
-    SquatDetectionMapper.reset()
-    BridgeDetectionMapper.reset()
-}

--- a/app/src/main/java/com/yogaflow/coach/BridgeDetectionMapper.kt
+++ b/app/src/main/java/com/yogaflow/coach/BridgeDetectionMapper.kt
@@ -6,7 +6,7 @@ import com.yogaflow.pose.PoseDetectionResult
 import com.yogaflow.pose.PoseGeometry
 import kotlin.math.abs
 
-object BridgeDetectionMapper {
+class BridgeDetectionMapper {
 
     data class Result(val matched: Boolean, val state: CoachState, val cue: String, val reason: String = "")
 

--- a/app/src/main/java/com/yogaflow/coach/DetectionMapperSession.kt
+++ b/app/src/main/java/com/yogaflow/coach/DetectionMapperSession.kt
@@ -1,0 +1,22 @@
+package com.yogaflow.coach
+
+class DetectionMapperSession(
+    private val forwardFoldDetectionMapper: ForwardFoldDetectionMapper = ForwardFoldDetectionMapper(),
+    private val twistDetectionMapper: TwistDetectionMapper = TwistDetectionMapper(),
+    private val squatDetectionMapper: SquatDetectionMapper = SquatDetectionMapper(),
+    private val bridgeDetectionMapper: BridgeDetectionMapper = BridgeDetectionMapper()
+) {
+    val poseDetectionRouter: PoseDetectionRouter = PoseDetectionRouter(
+        forwardFoldDetectionMapper = forwardFoldDetectionMapper,
+        twistDetectionMapper = twistDetectionMapper,
+        squatDetectionMapper = squatDetectionMapper,
+        bridgeDetectionMapper = bridgeDetectionMapper
+    )
+
+    fun resetAll() {
+        forwardFoldDetectionMapper.reset()
+        twistDetectionMapper.reset()
+        squatDetectionMapper.reset()
+        bridgeDetectionMapper.reset()
+    }
+}

--- a/app/src/main/java/com/yogaflow/coach/ForwardFoldDetectionMapper.kt
+++ b/app/src/main/java/com/yogaflow/coach/ForwardFoldDetectionMapper.kt
@@ -6,7 +6,7 @@ import com.yogaflow.pose.PoseDetectionResult
 import com.yogaflow.pose.PoseGeometry
 import kotlin.math.abs
 
-object ForwardFoldDetectionMapper {
+class ForwardFoldDetectionMapper {
 
     data class Result(val matched: Boolean, val state: CoachState, val cue: String, val reason: String = "")
 

--- a/app/src/main/java/com/yogaflow/coach/PoseDetectionRouter.kt
+++ b/app/src/main/java/com/yogaflow/coach/PoseDetectionRouter.kt
@@ -5,7 +5,12 @@ import com.yogaflow.flow.RuntimeParams
 import com.yogaflow.pose.PoseDetectionResult
 import com.yogaflow.yoga.YogaPose
 
-object PoseDetectionRouter {
+class PoseDetectionRouter(
+    private val forwardFoldDetectionMapper: ForwardFoldDetectionMapper = ForwardFoldDetectionMapper(),
+    private val twistDetectionMapper: TwistDetectionMapper = TwistDetectionMapper(),
+    private val squatDetectionMapper: SquatDetectionMapper = SquatDetectionMapper(),
+    private val bridgeDetectionMapper: BridgeDetectionMapper = BridgeDetectionMapper()
+) {
 
     fun evaluate(
         poseId: String,
@@ -18,19 +23,19 @@ object PoseDetectionRouter {
 
         return when (poseId) {
             "forward_fold" -> {
-                val r = ForwardFoldDetectionMapper.evaluate(detect, frame, params)
+                val r = forwardFoldDetectionMapper.evaluate(detect, frame, params)
                 PoseDetectionMappingResult(r.matched, r.state, r.cue, if (!r.matched) r.reason else "")
             }
             "twist" -> {
-                val r = TwistDetectionMapper.evaluate(detect, frame, params)
+                val r = twistDetectionMapper.evaluate(detect, frame, params)
                 PoseDetectionMappingResult(r.matched, r.state, r.cue, if (!r.matched) r.reason else "")
             }
             "squat" -> {
-                val r = SquatDetectionMapper.evaluate(detect, frame, params)
+                val r = squatDetectionMapper.evaluate(detect, frame, params)
                 PoseDetectionMappingResult(r.matched, r.state, r.cue, if (!r.matched) r.reason else "")
             }
             "bridge" -> {
-                val r = BridgeDetectionMapper.evaluate(detect, frame, params)
+                val r = bridgeDetectionMapper.evaluate(detect, frame, params)
                 PoseDetectionMappingResult(r.matched, r.state, r.cue, if (!r.matched) r.reason else "")
             }
             "mountain" -> {

--- a/app/src/main/java/com/yogaflow/coach/SquatDetectionMapper.kt
+++ b/app/src/main/java/com/yogaflow/coach/SquatDetectionMapper.kt
@@ -6,7 +6,7 @@ import com.yogaflow.pose.PoseDetectionResult
 import com.yogaflow.pose.PoseGeometry
 import kotlin.math.abs
 
-object SquatDetectionMapper {
+class SquatDetectionMapper {
 
     data class Result(val matched: Boolean, val state: CoachState, val cue: String, val reason: String = "")
 

--- a/app/src/main/java/com/yogaflow/coach/TwistDetectionMapper.kt
+++ b/app/src/main/java/com/yogaflow/coach/TwistDetectionMapper.kt
@@ -6,7 +6,7 @@ import com.yogaflow.pose.PoseDetectionResult
 import com.yogaflow.pose.PoseGeometry
 import kotlin.math.abs
 
-object TwistDetectionMapper {
+class TwistDetectionMapper {
 
     data class Result(val matched: Boolean, val state: CoachState, val cue: String, val reason: String = "")
 

--- a/app/src/main/java/com/yogaflow/session/LiveCoachSessionController.kt
+++ b/app/src/main/java/com/yogaflow/session/LiveCoachSessionController.kt
@@ -1,7 +1,6 @@
 package com.yogaflow.session
 
 import com.yogaflow.coach.CoachState
-import com.yogaflow.coach.PoseDetectionRouter
 import com.yogaflow.coach.PoseFlowEngine
 import com.yogaflow.coach.PoseStateMachine
 import com.yogaflow.flow.AutoTuningAdvisor
@@ -15,6 +14,7 @@ import com.yogaflow.flow.YogaFlow
 class LiveCoachSessionController(
     private val stateMachine: PoseStateMachine,
     private val flowEngine: PoseFlowEngine,
+    private val poseDetectionRouter: PoseDetectionRouter,
     private val runtimeOverrideStore: RuntimeOverrideStore,
     private val autoTuningAdvisor: AutoTuningAdvisor,
     private val onFlowCompleted: (String) -> Unit,
@@ -55,7 +55,7 @@ class LiveCoachSessionController(
         val runtimeSummary = buildRuntimeSummary(effectiveParams)
         val overrideSummary = buildOverrideSummary()
 
-        val mapping = PoseDetectionRouter.evaluate(
+        val mapping = poseDetectionRouter.evaluate(
             poseId = currentPose.id,
             detect = currentStep.detect,
             params = effectiveParams,


### PR DESCRIPTION
### Motivation
- Replace global singleton mapper state with session-owned instances so smoothing/stability state is instance-scoped and can be reset per-session. 
- Centralize reset/orchestration of detection mappers to a single owner to address lifecycle issues and align with issue goals (#33, #34, #35).

### Description
- Converted the four detection mappers (`ForwardFoldDetectionMapper`, `TwistDetectionMapper`, `SquatDetectionMapper`, `BridgeDetectionMapper`) from `object` singletons to `class` instances so internal smoothing/stability fields are per-instance.
- Refactored `PoseDetectionRouter` from an `object` into an instance `class` that receives the mapper instances via constructor injection and delegates evaluation to those instances.
- Added `DetectionMapperSession` which owns mapper instances, exposes a `poseDetectionRouter` bound to them, and provides `resetAll()` to reset all mapper states.
- Updated application wiring to use the session-owned API: replaced direct static resets with `detectionMapperSession.resetAll()` in `MainActivityPlaylist`, and injected/used a `PoseDetectionRouter` instance in `LiveCoachSessionController`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin -q`, but the command failed because `./gradlew` is not present in this environment (compile not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f717562494832fafbe73f5c037d76a)