### PR TITLE
Docs: productized README (pitch-aligned landing page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,172 @@
 # YogaFlow 3D
 
-> **自己的資訊，自己掌控。數據零離機，專業不妥協。**
+> Visual AI Yoga Coach — see your mistakes, fix them in real time, and keep your movement data on your own device.
 
-YogaFlow 3D is a production-oriented on-device AI yoga coach for Android. It turns live camera frames into 3D pose geometry, maps the user’s body state to structured yoga flow steps, and gives real-time voice coaching through local LLM + TTS.
+YogaFlow 3D is an Android, on-device AI yoga coaching app. It turns live camera frames into pose geometry, evaluates the user against structured yoga flow steps, and gives real-time visual / voice guidance.
+
+**數據自主 • 即時引導 • 個性化成長**
 
 ---
 
-## ✨ Flow DSL
+## Why it matters
 
-YogaFlow uses a **JSON DSL v2**, type-safe, strict Flow DSL.
+Most home yoga practice is still one-way video playback. The user follows a teacher, but cannot see whether their knees are bending, their hips are aligned, or their spine is collapsing.
+
+YogaFlow 3D addresses this visual blind spot:
+
+- Real-time body pose tracking
+- Joint-angle based correction
+- Flow-based lesson progression
+- Local-first privacy model
+- Personalized movement tuning over time
+
+The long-term vision is simple:
+
+> Make expert movement feedback available at home, without sending private camera data to the cloud.
+
+---
+
+## Product vision
+
+YogaFlow 3D starts with yoga, but the underlying system is a motion-intelligence platform.
+
+Potential expansion areas:
+
+- physical therapy
+- mobility training
+- dance learning
+- sports form correction
+- post-injury movement recovery
+
+The current implementation focuses on a practical MVP: live camera pose detection, strict flow execution, angle-based feedback, and voice coaching.
+
+---
+
+## Current capability
+
+```text
+Camera → Pose Detection → Geometry → Strict Mapper → Flow Engine → Coach Cue
+```
+
+Implemented core pieces:
+
+- Android native app
+- CameraX live camera pipeline
+- MediaPipe pose integration
+- 3D / 2D fallback geometry helpers
+- JSON Flow DSL v2
+- strict `DetectKey` validation
+- pose-specific detection mappers
+- runtime tuning overrides
+- auto tuning suggestions from numeric fail reasons
+- debug overlay for explainability
+- LLM-assisted phrase polishing
+- TTS voice coaching
+
+Current limitation:
+
+```text
+YouTube / teacher-video auto extraction is not fully automated yet.
+```
+
+Today, YogaFlow uses structured Flow JSON. Flows can be authored manually or prepared with AI assistance, but the app does not yet provide a complete automatic YouTube-to-flow pipeline.
+
+---
+
+## How it works
+
+### 1. Flow JSON defines the lesson
+
+The lesson sequence is not improvised by the LLM. It is defined by a strict Flow DSL.
+
+```json
+{
+  "state": "HOLD",
+  "durationMs": 8000,
+  "cue": "停在這裡，保持呼吸。",
+  "detect": "forward_hold",
+  "runtime": {
+    "stabilityMs": 650,
+    "emaAlpha": 0.25,
+    "angles": {
+      "knee": { "hold": { "min": 145 } },
+      "hip": { "hold": { "min": 50, "max": 130 } }
+    }
+  }
+}
+```
+
+### 2. Camera frames become pose geometry
+
+```text
+CameraPosePipeline
+        ↓
+PoseDetectionResult
+        ↓
+PoseGeometry
+```
+
+### 3. Pose-specific mappers evaluate body state
+
+```text
+DetectKey + RuntimeParams + PoseDetectionResult
+        ↓
+ForwardFoldDetectionMapper / SquatDetectionMapper / TwistDetectionMapper / BridgeDetectionMapper
+        ↓
+matched / not matched + reason + cue
+```
+
+### 4. The flow engine advances the class
+
+```text
+PoseDetectionRouter
+        ↓
+PoseFlowEngine
+        ↓
+CoachCueController
+        ↓
+CoachSpeaker / LlmCoach / TTS
+```
+
+---
+
+## Architecture
+
+```text
+CameraPosePipeline
+        ↓
+PoseDetectionResult
+        ↓
+MainActivity.handlePoseFrame
+        ↓
+LiveCoachSessionController
+        ↓
+RuntimeOverrideMerger
+        ↓
+PoseDetectionRouter
+        ↓
+Pose-specific Detection Mapper
+        ↓
+PoseFlowEngine
+        ↓
+CoachCueController
+        ↓
+LlmCoach + CoachPhrasePolisher + CoachSpeaker/TTS
+```
+
+Design rule:
+
+```text
+Flow JSON is the source of truth.
+LLM must not plan, reorder, or invent lesson steps.
+LLM can only adapt phrase tone for flow-provided cues.
+```
+
+---
+
+## Flow DSL
+
+YogaFlow uses a type-safe JSON DSL v2.
 
 ```text
 .flow.json
@@ -22,358 +180,7 @@ YogaFlow uses a **JSON DSL v2**, type-safe, strict Flow DSL.
 → PoseFlowEngine
 ```
 
-Supported:
-
-```text
-app/src/main/assets/flows/*.flow.json
-flows/*.flow.json
-```
-
-Each strict detection flow can define flow-level runtime defaults:
-
-```json
-{
-  "defaults": {
-    "runtime": {
-      "stabilityMs": 300,
-      "emaAlpha": 0.35,
-      "deadbandDegrees": 3
-    }
-  }
-}
-```
-
-Each step defines only its detection-specific angles unless it needs to override defaults:
-
-```json
-{
-  "detect": "forward_hold",
-  "runtime": {
-    "stabilityMs": 650,
-    "emaAlpha": 0.25,
-    "angles": {
-      "knee": { "hold": { "min": 145 } },
-      "hip": { "hold": { "min": 50, "max": 130 } }
-    }
-  }
-}
-```
-
-Full spec:
-
-```text
-docs/flow-dsl.md
-```
-
----
-
-## App Controller Architecture
-
-MainActivity is intentionally kept as the Android shell: lifecycle, permissions, view binding, camera lifecycle, and wiring. Live coaching logic is split into controllers.
-
-```text
-CameraPosePipeline
-        ↓
-PoseDetectionResult
-        ↓
-MainActivity.handlePoseFrame
-        ├─ Camera setup gate
-        │      CameraFramingCoach + ViewOrientation
-        │
-        └─ LiveCoachSessionController
-               RuntimeOverrideMerger
-               PoseDetectionRouter
-               PoseFlowEngine
-               AutoTuningAdvisor
-               FlowEvent
-                    ↓
-             CoachCueController
-               LlmCoach + CoachPhrasePolisher + CoachSpeaker/TTS
-```
-
-Current responsibility split:
-
-```text
-MainActivity
-  Android lifecycle, permission, camera start/stop, UI wiring, playlist buttons, controller callbacks
-
-CoachCueController
-  LLM generation, phrase polishing, fallback detection, TTS, cue rate limiting, async request cancellation
-
-LiveCoachSessionController
-  ready pose frame handling, runtime override merge, pose detection routing, flow events, debug/tuning callbacks
-
-CameraSetupController
-  intended owner of full-body framing, orientation, ready gate, setup correction cues, and auto-start wiring
-```
-
-Current integration status:
-
-```text
-CoachCueController: integrated in MainActivity
-LiveCoachSessionController: integrated in MainActivity
-CameraSetupController: file exists; MainActivity still uses handleCameraSetupFrame as the stable pre-integration baseline
-```
-
-Design rule:
-
-```text
-LLM must not plan or reorder lessons.
-LLM is only a phrase / tone adapter for flow-provided cues.
-Flow JSON remains the source of truth for lesson sequence and detection behavior.
-```
-
----
-
-## Runtime Tuning Architecture
-
-```text
-                         ┌──────────────────────────┐
-                         │     Flow JSON (DSL)      │
-                         │  assets/flows/*.json     │
-                         └────────────┬─────────────┘
-                                      │
-                                      ▼
-                         ┌──────────────────────────┐
-                         │       FlowLoader         │
-                         │   parse + validation     │
-                         └────────────┬─────────────┘
-                                      │
-                                      ▼
-                         ┌──────────────────────────┐
-                         │      RuntimeParams       │
-                         │   typed DSL params       │
-                         └────────────┬─────────────┘
-                                      │
-                     ┌────────────────┴────────────────┐
-                     │                                 │
-                     ▼                                 ▼
-     ┌──────────────────────────┐        ┌──────────────────────────┐
-     │ TunableParamExtractor    │        │   RuntimeOverrideStore   │
-     │ DSL → UI params          │        │ user tuning layer        │
-     └────────────┬─────────────┘        └────────────┬─────────────┘
-                  │                                   │
-                  ▼                                   ▼
-        ┌──────────────────────┐           ┌────────────────────────┐
-        │   Slider UI          │           │  RuntimeOverrideKey    │
-        │ dynamic binding      │           │ flow/step/detect/path  │
-        └────────────┬─────────┘           └────────────┬───────────┘
-                     │                                  │
-                     └──────────────┬───────────────────┘
-                                    ▼
-                         ┌──────────────────────────┐
-                         │  RuntimeOverrideMerger   │
-                         │ DSL + override merge     │
-                         └────────────┬─────────────┘
-                                      │
-                                      ▼
-                         ┌──────────────────────────┐
-                         │  EffectiveRuntimeParams  │
-                         │ final detection config   │
-                         └────────────┬─────────────┘
-                                      │
-                                      ▼
-                         ┌──────────────────────────┐
-                         │  PoseDetectionRouter     │
-                         │ detect + mapper logic    │
-                         └────────────┬─────────────┘
-                                      │
-                                      ▼
-                         ┌──────────────────────────┐
-                         │   PoseFlowEngine         │
-                         │ state machine + flow     │
-                         └────────────┬─────────────┘
-                                      │
-                                      ▼
-                         ┌──────────────────────────┐
-                         │     Coach Output         │
-                         │ voice / UI feedback      │
-                         └──────────────────────────┘
-```
-
-Minimal mental model:
-
-```text
-DSL → Runtime → Override → Detection → Explain
-```
-
----
-
-## Runtime Overrides
-
-Runtime tuning is scoped by flow, step, detect key, and parameter path:
-
-```kotlin
-data class RuntimeOverrideKey(
-    val flowId: String,
-    val stepIndex: Int,
-    val detect: DetectKey,
-    val path: String
-)
-```
-
-Example override paths:
-
-```text
-runtime.stabilityMs
-runtime.emaAlpha
-runtime.deadbandDegrees
-runtime.angles.knee.hold.min
-runtime.angles.hip.hold.max
-```
-
-The packaged flow JSON remains the source of truth. User tuning is applied as a runtime override layer and merged into effective runtime params for detection.
-
----
-
-## Adaptive Auto Tuning
-
-YogaFlow can observe numeric fail reasons and propose runtime tuning suggestions without mutating packaged flow JSON.
-
-```text
-numeric FAIL reason
-        ↓
-AutoTuningAdvisor.observeReason(...)
-        ↓
-recent scoped samples
-        ↓
-average actual angle
-        ↓
-AutoTuningSuggestion
-        ↓
-RuntimeOverrideStore apply action
-```
-
-Example fail reason:
-
-```text
-FAIL: knee=138.2 < min=145.0
-```
-
-Example suggestion:
-
-```text
-SUGGEST: knee.min 145.0 → 140.0 (9 samples, medium)
-```
-
-Suggestion confidence is currently based on sample count:
-
-```text
-15+ samples → high
-8+ samples  → medium
-5+ samples  → low
-```
-
-Apply behavior:
-
-```text
-Apply button / restart long-press
-        ↓
-applyLatestSuggestion()
-        ↓
-RuntimeOverrideStore.set(...)
-        ↓
-slider + detection update immediately
-```
-
-Design rules:
-
-```text
-Flow JSON is never mutated
-suggestions are user-in-the-loop
-runtime override is the only write target
-suggestions are scoped by flow / step / detect
-stability timing failures are ignored for angle tuning
-```
-
-Current limitation:
-
-```text
-confidence is sample-count based only
-variance-based confidence is planned
-multi-param apply is planned
-```
-
----
-
-## Product Experience
-
-```text
-Beginner Class
-Mountain → Forward Fold → Twist → Squat → Bridge
-```
-
-- Platform: Android
-- Runtime: On-device camera + pose + coach loop
-- Coaching mode: live correction + flow progression
-- Camera onboarding: setup panel, ready gating, stable auto-start
-- Visual feedback: body framing box + fixed guide frame
-- Debug mode: live pose angle / state / matched overlay
-- Flow language: JSON Flow DSL v2
-- Detection runtime: `DetectKey + RuntimeParams`
-- Privacy: no camera frames or pose landmarks need to leave the device
-
----
-
-## Core Architecture
-
-```text
-CameraPosePipeline
-        ↓
-PoseDetectionResult
-        ↓
-PoseGeometry
-        ↓
-LiveCoachSessionController
-        ↓
-PoseDetectionRouter
-        ↓
-Pose-specific Detection Mapper
-        ↓
-PoseFlowEngine
-        ↓
-CoachCueController
-        ↓
-CoachSpeaker / LlmCoach / TTS
-```
-
-### Flow Runtime
-
-```text
-FlowLoader
-        ↓
-FlowJsonValidator
-        ↓
-FlowParser
-        ↓
-YogaFlow / YogaFlowStep
-        ↓
-FlowValidator
-        ↓
-PoseFlowEngine
-```
-
-### Strict Detection Runtime
-
-```text
-JSON detect string
-        ↓
-DetectKey enum
-        ↓
-RuntimeParams typed model
-        ↓
-RuntimeOverrideStore
-        ↓
-EffectiveRuntimeParams
-        ↓
-Strict mapper evaluation
-```
-
----
-
-## Flow Files
-
-Production flows live in:
+Flow files live in:
 
 ```text
 app/src/main/assets/flows/
@@ -389,118 +196,136 @@ Current production flows:
 05_bridge.flow.json
 ```
 
-Demo flows may live in:
+Full DSL notes:
 
 ```text
-flows/
+docs/flow-dsl.md
 ```
 
 ---
 
-## Detection Mappers
+## Runtime tuning
 
-Pose-specific mappers evaluate typed detect keys and typed runtime params.
+YogaFlow separates packaged lesson design from user-specific runtime tuning.
 
 ```text
-ForwardFoldDetectionMapper
-SquatDetectionMapper
-TwistDetectionMapper
-BridgeDetectionMapper
+Flow JSON defaults
+        ↓
+RuntimeParams
+        ↓
+RuntimeOverrideStore
+        ↓
+RuntimeOverrideMerger
+        ↓
+EffectiveRuntimeParams
+        ↓
+Detection Mapper
 ```
 
-Mapper contract:
+Override keys are scoped by:
 
 ```kotlin
-fun evaluate(
-    detect: DetectKey,
-    frame: PoseDetectionResult,
-    params: RuntimeParams
-): Result
+data class RuntimeOverrideKey(
+    val flowId: String,
+    val stepIndex: Int,
+    val detect: DetectKey,
+    val path: String
+)
 ```
 
-Strict policy:
+Example paths:
 
 ```text
-missing required runtime param → error
-missing required angle param → error
-unsupported detect in mapper → error
+runtime.stabilityMs
+runtime.emaAlpha
+runtime.deadbandDegrees
+runtime.angles.knee.hold.min
+runtime.angles.hip.hold.max
 ```
 
 ---
 
-## Camera Onboarding
+## Explainable feedback
 
-Before a class starts, YogaFlow checks:
+YogaFlow tries to make every correction debuggable.
 
-```text
-full-body framing
-view orientation
-camera readiness stability
-```
-
-When the user is ready and stable, the class can auto-start.
+Example numeric fail reason:
 
 ```text
-CameraFramingCoach
-ViewOrientation
-Ready Gate
-Auto-start Timer
+knee=138.2 < min=145.0
 ```
 
-Current implementation:
+Example auto tuning suggestion:
 
 ```text
-MainActivity.handleCameraSetupFrame is the stable baseline.
-CameraSetupController exists and is intended to own this logic after final integration.
+knee.min 145.0 → 140.0 (9 samples, medium confidence)
 ```
+
+Debug overlay can show:
+
+- detect key
+- coach state
+- matched / not matched
+- runtime params
+- active overrides
+- fail reason
+- tuning suggestion
 
 ---
 
-## Debug Overlay
+## Privacy model
 
-Debug mode displays pose, runtime, override data, fail reason, and tuning suggestions for explainability:
-
-```text
-pose id
-detect key
-coach state
-matched / not matched
-knee angle
-hip angle
-torso twist estimate
-effective runtime params
-active runtime overrides
-numeric fail reason
-auto tuning suggestion
-```
-
-Example:
-
-```text
-runtime=stab=650 ema=0.25 dead=3.0 | knee.hold.min=145 hip.hold.max=130
-overrides=knee.hold.min=150
-FAIL: knee=138.2 < min=145.0
-SUGGEST: knee.min 145.0 → 140.0 (9 samples, medium)
-```
-
-This makes each detection result traceable to pose data, DSL runtime params, user tuning overrides, and adaptive suggestions.
-
----
-
-## Privacy Model
-
-YogaFlow is designed around on-device processing.
+YogaFlow is designed around local-first processing.
 
 ```text
 camera frames stay on device
 pose landmarks stay on device
 flow execution is local
-voice coaching can be local
+coaching can run locally
+```
+
+This is important because yoga practice happens in private spaces.
+
+---
+
+## Pitch deck
+
+The product proposal is available as a Google Slides pitch deck:
+
+```text
+https://docs.google.com/presentation/d/1e0uUybgMie-YGJHSP8k9FjXeGxIeCdmMKvC8RVVI-nk/edit?usp=drivesdk
+```
+
+Pitch theme:
+
+```text
+視覺化智慧：重新定義居家瑜珈
 ```
 
 ---
 
-## Development Notes
+## Roadmap
+
+Near-term engineering priorities:
+
+- restore full CameraSetupController wiring in MainActivity
+- add CI validation for all Flow JSON files
+- persist runtime overrides
+- improve mapper lifecycle tests
+- add strict MountainDetectionMapper
+- add variance-based tuning confidence
+- build a Flow Editor UI
+- explore AI-assisted teacher-video-to-flow authoring
+
+Tracked roadmap:
+
+```text
+docs/detection-refactor-roadmap.md
+```
+
+---
+
+## Development notes
 
 Recommended validation before merging flow changes:
 
@@ -509,36 +334,15 @@ Recommended validation before merging flow changes:
 2. Confirm FlowJsonValidator passes
 3. Confirm FlowValidator passes
 4. Run app and inspect debug overlay
-5. Verify Apply button / restart long-press only writes runtime overrides
+5. Verify suggestions write only to RuntimeOverrideStore
 ```
 
-Safe refactor rule for MainActivity:
+Safe refactor rule:
 
 ```text
 Do not patch MainActivity with placeholder content.
-When using GitHub content API, always fetch current SHA and write a complete Kotlin file.
+When using GitHub contents API, always fetch the current SHA and write a complete Kotlin file.
 Prefer local IDE refactor for controller integration.
-```
-
----
-
-## Roadmap
-
-```text
-Integrate CameraSetupController into MainActivity
-CI validation for all flow JSON files
-Runtime override persistence
-Multi-param tuning UI
-Variance-based confidence
-Multi-param suggestion apply
-Flow Editor UI
-DSL v3 constraint expressions
-```
-
-Example DSL direction:
-
-```text
-knee > 145 && hip in 50..130
 ```
 
 ---
@@ -546,19 +350,23 @@ knee > 145 && hip in 50..130
 ## Status
 
 ```text
-JSON DSL v2
-DetectKey enum
-RuntimeParams typed model
-Strict mappers
-Flow-level defaults
-Runtime override store
-Dynamic tuning UI
-Debug explainability
-Numeric fail reason
-Auto tuning advisor
-Sample-count confidence
-Apply suggestion action
-CoachCueController integrated
-LiveCoachSessionController integrated
-CameraSetupController exists, pending MainActivity integration
+Status: active prototype / architecture hardening
+Platform: Android
+Core: CameraX + MediaPipe + Flow DSL + local coach loop
+Privacy: local-first
+```
+
+Current known gap:
+
+```text
+CameraSetupController exists, but latest main still needs final MainActivity wiring cleanup.
+```
+
+---
+
+## Contact
+
+```text
+GitHub: WangChengYeh/Yoga
+Email: contact@yogaflow3d.ai
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# YogaFlow 3D Architecture (v7)
+# YogaFlow 3D Architecture (v8)
 
 YogaFlow 3D 是一個 production-oriented on-device AI 瑜伽教練系統。
 
@@ -12,6 +12,16 @@ Camera → Perception → Onboarding Gate → Detection Mapping → Flow → Coa
                     Observability
                          ↓
                       Tuning
+```
+
+Architecture design principles:
+
+```text
+Flow JSON is the lesson source of truth.
+Detection must be explicit and debuggable.
+LLM may adapt phrasing, but must not plan or reorder lessons.
+Camera and pose data should stay on device.
+Runtime tuning must not mutate packaged Flow JSON.
 ```
 
 ---
@@ -50,6 +60,20 @@ LLM Coach / Fallback
 TTS Voice
 ```
 
+Target controller pipeline:
+
+```text
+MainActivity.handlePoseFrame
+  ↓
+CameraSetupController.handleFrame
+  ↓
+LiveCoachSessionController.handleReadyPoseFrame
+  ↓
+CoachCueController
+```
+
+`MainActivity` should remain the Android shell: lifecycle, permissions, view binding, camera lifecycle, and callback wiring.
+
 ---
 
 ## Camera Onboarding Pipeline
@@ -74,7 +98,7 @@ FlowEngine
 
 The onboarding layer prevents users from entering a class until the system has reliable camera framing and view orientation.
 
-Current onboarding behavior:
+Current intended onboarding behavior:
 
 ```text
 Not Ready
@@ -84,6 +108,15 @@ Not Ready
 → hold Ready for ~1500ms
 → auto-start class
 ```
+
+Known integration gap:
+
+```text
+CameraSetupController exists, but latest main still needs final MainActivity wiring cleanup.
+MainActivity still contains local handleCameraSetupFrame logic.
+```
+
+This gap should be fixed before further feature work.
 
 ---
 
@@ -112,6 +145,65 @@ Purpose:
 
 ---
 
+## Flow DSL Runtime
+
+YogaFlow lessons are defined by JSON Flow DSL v2.
+
+```text
+.flow.json
+  ↓
+FlowJsonValidator
+  ↓
+FlowParser
+  ↓
+DetectKey
+  ↓
+RuntimeParams
+  ↓
+FlowValidator
+  ↓
+PoseFlowEngine
+```
+
+Flow JSON defines:
+
+- step state
+- duration
+- cue text
+- detect key
+- correction text
+- runtime thresholds
+- smoothing parameters
+- stability timing
+
+Example step:
+
+```json
+{
+  "state": "HOLD",
+  "durationMs": 8000,
+  "cue": "停在這裡，保持呼吸。",
+  "detect": "forward_hold",
+  "runtime": {
+    "stabilityMs": 650,
+    "emaAlpha": 0.25,
+    "angles": {
+      "knee": { "hold": { "min": 145 } },
+      "hip": { "hold": { "min": 50, "max": 130 } }
+    }
+  }
+}
+```
+
+Important rule:
+
+```text
+Flow JSON remains the source of truth.
+LLM cannot invent, remove, or reorder flow steps.
+```
+
+---
+
 ## Observability + Tuning Pipeline
 
 The runtime exposes a debug overlay and threshold tuning panel for validation and calibration:
@@ -125,9 +217,11 @@ DebugPoseInfo
   ↓
 debugText overlay
   ↓
-Threshold UI
+Threshold UI / Runtime Override UI
   ↓
-ThresholdConfig
+RuntimeOverrideStore
+  ↓
+RuntimeOverrideMerger
   ↓
 Detection Mapper
 ```
@@ -148,24 +242,39 @@ matched
 left / right knee angle
 left / right hip angle
 torso twist estimate
+effective runtime params
+active runtime overrides
+numeric fail reason
+auto tuning suggestion
 ```
 
-Threshold UI currently supports:
+Runtime override paths are scoped by flow, step, detect key, and parameter path:
+
+```kotlin
+data class RuntimeOverrideKey(
+    val flowId: String,
+    val stepIndex: Int,
+    val detect: DetectKey,
+    val path: String
+)
+```
+
+Example paths:
 
 ```text
-Squat knee hold max threshold
-Bridge hip lift / hold max threshold
+runtime.stabilityMs
+runtime.emaAlpha
+runtime.deadbandDegrees
+runtime.angles.knee.hold.min
+runtime.angles.hip.hold.max
 ```
 
-Threshold values are persisted with `SharedPreferences`, so user calibration survives app restarts.
+Design rule:
 
-Purpose:
-
-- tune pose thresholds
-- inspect jitter
-- validate stability window behavior
-- understand why a step is or is not matched
-- preserve user-specific calibration
+```text
+Packaged Flow JSON is never mutated.
+User tuning is applied through RuntimeOverrideStore only.
+```
 
 ---
 
@@ -185,8 +294,9 @@ Each mapper:
 - converts geometry → semantic state
 - applies threshold rules
 - applies smoothing + stability window
-- reads runtime threshold config when supported
-- outputs `(matched, state, cue)`
+- reads typed RuntimeParams
+- outputs matched / not matched result
+- provides numeric fail reasons when possible
 
 Mapping dispatch is handled by:
 
@@ -194,7 +304,51 @@ Mapping dispatch is handled by:
 PoseDetectionRouter
 ```
 
-This keeps `MainActivity` focused on session orchestration and UI, while mapper selection stays in the coach layer.
+Current strict routing behavior:
+
+```text
+unsupported poseId → error
+unsupported detect key in mapper → error
+missing required runtime param → error
+```
+
+Current exception:
+
+```text
+mountain still uses legacy PoseStateMachine fallback
+```
+
+Planned direction:
+
+```text
+add strict MountainDetectionMapper
+remove final fallback path
+```
+
+---
+
+## Detection Mapper Session
+
+Detection mappers contain smoothing and stability-window state. This state must be scoped to a live coaching session, not shared globally.
+
+Current lifecycle owner:
+
+```text
+DetectionMapperSession
+  ├─ ForwardFoldDetectionMapper
+  ├─ TwistDetectionMapper
+  ├─ SquatDetectionMapper
+  └─ BridgeDetectionMapper
+```
+
+Responsibilities:
+
+- create mapper instances
+- expose a configured `PoseDetectionRouter`
+- reset mapper state on playlist restart
+- reset mapper state on flow transition
+
+This prevents cross-flow contamination and prepares the architecture for future multi-session support.
 
 ---
 
@@ -221,7 +375,7 @@ All pose mappers use:
 
 - EMA smoothing
 - deadband filtering
-- stability window (~300ms)
+- stability window
 - cue throttling
 
 Purpose:
@@ -277,6 +431,45 @@ System decides WHAT
 LLM decides HOW
 ```
 
+`CoachCueController` owns:
+
+- cue rate limiting
+- stale async request cancellation
+- LLM phrase polishing
+- deterministic fallback cue
+- final TTS output
+
+---
+
+## Session State
+
+Current session states:
+
+```text
+IDLE
+RUNNING
+PAUSED
+COMPLETED
+```
+
+Recommended ownership:
+
+```text
+session/SessionState.kt
+```
+
+Reason:
+
+- avoid defining session lifecycle inside `MainActivity.kt`
+- improve reuse across controllers
+- reduce package coupling
+
+Known gap:
+
+```text
+SessionState is still defined in MainActivity.kt in latest main.
+```
+
 ---
 
 ## Current Capability
@@ -287,18 +480,26 @@ LLM decides HOW
 ✔ Squat
 ✔ Bridge
 ✔ Full beginner class (5 poses)
-✔ Camera setup panel before class start
-✔ Ready gating from framing + orientation
-✔ Stable auto-start after sustained Ready state
-✔ Visual body framing box
-✔ Fixed framing guide frame
-✔ Event-driven runtime
-✔ Stability-aware detection
+✔ Flow JSON DSL v2
+✔ Strict DetectKey validation
+✔ RuntimeOverrideStore
+✔ RuntimeOverrideMerger
+✔ AutoTuningAdvisor
+✔ Numeric fail reasons
 ✔ PoseDetectionRouter mapper dispatch
+✔ DetectionMapperSession mapper lifecycle owner
 ✔ Debug overlay for angle / state / matched inspection
 ✔ Runtime threshold tuning UI
 ✔ Persistent user calibration with SharedPreferences
 ✔ LLM + TTS coaching
+```
+
+Partially integrated / known gaps:
+
+```text
+△ CameraSetupController exists, but final MainActivity wiring cleanup is still needed
+△ Mountain still uses legacy fallback
+△ Teacher-video-to-flow pipeline is not fully automated
 ```
 
 ---
@@ -307,8 +508,10 @@ LLM decides HOW
 
 ### Near-term
 
-- Add color-coded ready / not-ready visual states
-- Add direction-aware framing hints
+- Restore full CameraSetupController wiring in MainActivity
+- Move SessionState to a dedicated file
+- Add strict MountainDetectionMapper
+- Add Flow JSON CI validation
 - Add threshold reset button
 - Extract mapper interface (`PoseDetectionMapper`)
 
@@ -325,6 +528,41 @@ LLM decides HOW
 - Improve coaching personalization
 - Add calibration profiles / per-user presets
 - Replace cover drawable with real generated images (#13)
+- Explore AI-assisted teacher-video-to-flow authoring
+
+---
+
+## Recommended Next Architecture PRs
+
+### PR 1: Restore CameraSetupController wiring
+
+Scope:
+
+- route setup frames through `CameraSetupController.handleFrame(frame)`
+- remove local `MainActivity.handleCameraSetupFrame`
+- fix pause/resume readiness gating
+- decide auto-start behavior
+
+### PR 2: Extract SessionState
+
+Scope:
+
+- move `SessionState` into a dedicated file
+- update imports across controllers
+
+### PR 3: Strict MountainDetectionMapper
+
+Scope:
+
+- implement mapper for mountain pose
+- remove final legacy `PoseStateMachine` fallback path
+
+### PR 4: Flow JSON CI
+
+Scope:
+
+- validate every `*.flow.json` in CI
+- reject unsupported detect keys / missing runtime params
 
 ---
 
@@ -336,7 +574,22 @@ All processing is on-device
 
 - no camera upload
 - no pose upload
-- no cloud dependency
+- no cloud dependency required for core detection
 - debug overlay uses local pose geometry only
 - threshold calibration is stored locally
 - camera onboarding uses local landmarks only
+
+---
+
+## Architecture Summary
+
+```text
+Flow JSON defines the lesson.
+Camera detects the body.
+Geometry measures the pose.
+Mappers evaluate correctness.
+Flow engine advances the class.
+Coach controller speaks the cue.
+Runtime tuning adapts thresholds.
+Debug output explains every decision.
+```

--- a/docs/pitch.md
+++ b/docs/pitch.md
@@ -1,0 +1,285 @@
+# YogaFlow 3D Pitch
+
+> 視覺化智慧：重新定義居家瑜珈  
+> 數據自主 • 即時引導 • 個性化成長
+
+---
+
+## 1. 打破反饋黑箱
+
+為什麼多數居家練習者無法持續進步？
+
+因為他們看不見自己的錯誤。
+
+### 影片練習的侷限
+
+傳統瑜珈影片只有單向輸出。練習者無法得知自己的脊椎是否過度彎曲、關節角度是否安全，或動作是否真的達到教練示範的標準。
+
+### 昂貴的私教成本
+
+高品質私人教練成本高，且需要預約時間，難以滿足隨時隨地練習的需求。
+
+### 核心痛點
+
+> 自學者最大的問題不是不努力，而是缺少即時、可視化、可量化的回饋。
+
+---
+
+## 2. 視覺化關節引導
+
+### 「看見」看不見的角度
+
+YogaFlow 3D 透過手機鏡頭分析使用者姿勢，將身體動作轉換為可量化的關節角度與骨架狀態。
+
+系統可以比較：
+
+```text
+標準姿勢角度
+        vs
+使用者當前角度
+```
+
+並提供即時回饋。
+
+### 核心能力
+
+- 紅區警示：當關節偏離安全或目標範圍時提示使用者
+- 動態引導：用語音與畫面提示修正方向
+- 即時疊加：將骨架、角度與影像結合，讓錯誤變得可見
+
+---
+
+## 3. 個性化身體基線追蹤
+
+每個人的柔軟度、關節活動度與穩定度都不同。
+
+YogaFlow 3D 不只判斷「對或錯」，也建立個人化身體基線。
+
+### 活動度評估
+
+記錄每個關節的極限 ROM（Range of Motion），為每位使用者建立獨特的身體檔案。
+
+### 疲勞感知
+
+分析動作穩定度與姿勢波動，推估肌肉疲勞程度，適時建議休息，降低受傷風險。
+
+### 平衡分析
+
+透過重心追蹤與雙側角度對比，優化身體對稱性與核心穩定。
+
+---
+
+## 4. 進步路徑可視化
+
+YogaFlow 3D 不只是提醒「你做錯了」，而是告訴你：
+
+```text
+你距離目標還差多少？
+下一步該怎麼進步？
+```
+
+範例回饋：
+
+> 目前您的關節活動度已提升 25%，距離目標英雄三式尚有 12 度的傾斜優化空間。
+
+### 目標差距動態分析
+
+系統分析使用者與目標姿勢之間的角度差距，將練習轉換成可追蹤、可量化、可升級的過程。
+
+---
+
+## 5. 技術核心：感知與理解的結合
+
+YogaFlow 3D 的核心不是單純播放影片，而是即時理解使用者的身體狀態。
+
+### Edge-AI 視覺引擎
+
+利用 MediaPipe 進行高效能骨架抽取與 33 個關鍵點追蹤，支援側向、站姿、前彎、深蹲、橋式等姿勢分析。
+
+### Flow DSL 驅動課程
+
+課程不是由 LLM 隨機生成，而是由結構化 Flow JSON 定義：
+
+```text
+setup → movement → hold → correction → transition
+```
+
+每一步都可以指定：
+
+- 教練提示語
+- 偵測條件
+- 關節角度門檻
+- 穩定時間
+- 修正語句
+
+### 即時教練回饋
+
+系統根據偵測結果決定：
+
+```text
+是否完成目前步驟？
+是否需要修正？
+是否可以進入下一步？
+```
+
+LLM 只負責語氣潤飾，不負責改變課程順序。
+
+---
+
+## 6. 極致隱私：數據主權在使用者
+
+YogaFlow 3D 採用 local-first 設計。
+
+### 100% 離線推理目標
+
+影像分析與姿勢判斷在手機端完成，降低隱私風險。
+
+### 隱私承諾
+
+- 原始影像不需要離開裝置
+- 姿勢分析可在本地完成
+- 不依賴昂貴雲端訂閱
+- 可朝飛航模式可用的方向設計
+
+> 居家練習發生在高度私密的空間，AI 教練必須尊重資料主權。
+
+---
+
+## 7. 極簡練習流程
+
+### 01 匯入 / 選擇課程
+
+使用者選擇既有 Flow 課程，或未來透過影片輔助產生課程 Flow。
+
+### 02 3D 姿勢分析
+
+系統透過手機鏡頭提取使用者骨架與關節角度。
+
+### 03 互動練習
+
+即時視覺回饋與語音引導，協助使用者修正角度與穩定動作。
+
+### 04 成長回饋
+
+檢視目標差距、活動度變化與下一個訓練方向。
+
+---
+
+## 8. 競爭優勢分析
+
+| 功能特點 | 傳統瑜珈 App | 真人私教 | YogaFlow 3D |
+|---|---:|---:|---:|
+| 即時角度糾偏 | 弱 | 強 | 強 |
+| 個性化成長軌跡 | 弱 | 中 | 強 |
+| 視覺化骨架分析 | 弱 | 弱 | 強 |
+| 隱私數據安全性 | 常需雲端 | 無數據記錄 | 本地優先 |
+| 單次練習成本 | 低 | 高 | 低 |
+| 可隨時練習 | 強 | 弱 | 強 |
+
+YogaFlow 3D 的定位：
+
+```text
+比影片 App 更懂你的身體
+比真人私教更容易取得
+比雲端 AI 更保護隱私
+```
+
+---
+
+## 9. 未來的無限可能
+
+YogaFlow 3D 從瑜珈開始，但底層能力可延伸到更大的 movement intelligence 市場。
+
+### 延伸場景
+
+- 物理治療
+- 運動復健
+- 舞蹈教學
+- 健身動作修正
+- 高齡活動度訓練
+- 運動員姿勢分析
+
+### 平台願景
+
+> 建立一套可程式化、可量化、可解釋的 AI 動作教練平台。
+
+---
+
+## 10. 現階段產品落地狀態
+
+目前 repo 已具備：
+
+- Android app 架構
+- CameraX camera pipeline
+- MediaPipe pose integration
+- Flow JSON DSL
+- strict detection routing
+- pose-specific detection mappers
+- runtime tuning override
+- numeric fail reason
+- auto tuning suggestion
+- LLM-assisted coach cue
+- TTS voice output
+
+目前仍在進行：
+
+- CameraSetupController wiring cleanup
+- Flow JSON CI validation
+- runtime override persistence
+- strict mountain mapper
+- teacher-video-to-flow authoring pipeline
+
+---
+
+## 11. 關鍵產品原則
+
+### Flow JSON 是課程真相來源
+
+LLM 不應自由編排課程，不應新增影片中沒有的動作，也不應重排教學順序。
+
+### 動作必須可量化
+
+每個姿勢都應能被角度、穩定時間與偵測條件描述。
+
+### 回饋必須可解釋
+
+系統不只說「錯了」，也應說明：
+
+```text
+哪個角度錯？
+差多少？
+應該往哪裡修？
+```
+
+### 隱私是產品核心
+
+使用者的影像與身體資料不應成為雲端黑箱。
+
+---
+
+## 12. Closing
+
+YogaFlow 3D 的目標是讓每個人都能在家中獲得可視化、可量化、可持續進步的 AI 動作指導。
+
+> 讓科技守護隱私，讓 AI 成就專業。
+
+---
+
+## Links
+
+```text
+GitHub: WangChengYeh/Yoga
+Pitch deck: https://docs.google.com/presentation/d/1e0uUybgMie-YGJHSP8k9FjXeGxIeCdmMKvC8RVVI-nk/edit?usp=drivesdk
+Email: contact@yogaflow3d.ai
+```
+
+---
+
+## Image sources from original deck
+
+```text
+https://viso.ai/wp-content/uploads/2022/02/pose-estimation-human-ai-vision.png
+https://www.droid-life.com/wp-content/uploads/2024/12/AEKE-K1-1400x933.jpg
+https://www.mdpi.com/ai/ai-06-00180/article_deploy/html/images/ai-06-00180-g005.png
+https://pxl-tcdie.terminalfour.net/fit-in/855x9999/filters:no_upscale()/filters:format(webp)/filters:quality(100)/prod01/channel_3/media/tcd/engineering/images/App-KineMo-Screenshot.png
+```


### PR DESCRIPTION
Rewrite README to function as a product landing page instead of a pure engineering document.

Key changes:
- Add product vision and value proposition
- Align with pitch deck messaging
- Clarify current capabilities vs future roadmap
- Keep technical architecture but move it after product section
- Explicitly state current limitation (no full YouTube auto pipeline yet)

This PR does NOT change runtime behavior.

Goal:
Make the repo understandable to investors, engineers, and users in one entry point.