### PR TITLE
Guard avatar mapper against incomplete world landmarks

### DIFF
--- a/app/src/main/java/com/yogaflow/avatar/MediaPipeAvatarMapper.kt
+++ b/app/src/main/java/com/yogaflow/avatar/MediaPipeAvatarMapper.kt
@@ -17,10 +17,11 @@ object MediaPipeAvatarMapper {
     private const val R_KNEE = 26
     private const val L_ANKLE = 27
     private const val R_ANKLE = 28
+    private const val MIN_REQUIRED_LANDMARKS = R_ANKLE + 1
 
     fun map(frame: PoseDetectionResult): AvatarRigFrame {
         val l = frame.worldLandmarks
-        if (l.isEmpty()) {
+        if (l.size < MIN_REQUIRED_LANDMARKS) {
             return AvatarRigFrame(System.currentTimeMillis(), emptyList())
         }
 


### PR DESCRIPTION
## Summary

這個 PR 在 `MediaPipeAvatarMapper` 加上 landmark 數量檢查，避免 `worldLandmarks` 不完整時發生 `IndexOutOfBoundsException`。

目前 mapper 會使用 MediaPipe Pose 的固定 index，例如 shoulder、hip、knee、ankle，其中最大會讀到 `R_ANKLE = 28`。原本程式只檢查 `worldLandmarks.isEmpty()`，但這只代表 list 至少有 1 個元素，不代表可以安全讀取 index 28。

## Changes

- 新增 `MIN_REQUIRED_LANDMARKS = R_ANKLE + 1`
- 將原本的 `isEmpty()` 檢查改成 `size < MIN_REQUIRED_LANDMARKS`
- 當 landmark 數量不足時，回傳空的 `AvatarRigFrame`
- 保留正常完整 landmarks 情況下的既有行為

## Why

`MediaPipeAvatarMapper` 是 camera / pose pipeline 的 consumer。雖然 MediaPipe Pose 正常情況下通常回傳完整 landmarks，但 runtime frame 仍可能因為初始化、partial result、mock frame、或資料不完整而出現不足 29 個 world landmarks 的情況。

這個修正將原本隱含的資料需求明確化成程式碼 contract：

```text
worldLandmarks.size >= R_ANKLE + 1
```

避免在不完整輸入下直接 crash。

## Risk

Low.

正常完整 pose result 行為不變。只有在 landmarks 不足時，原本可能 crash，現在會回傳 empty rig frame。

## Test Plan

- Code review
- 確認 full landmark list 時原本 mapping 邏輯不變
- 確認 incomplete landmark list 時會 early return，不會讀取 out-of-bounds index