### PR TITLE
[codex] Fix review issues

### DIFF
--- a/app/src/main/assets/scripts/AvatarIKController.gd
+++ b/app/src/main/assets/scripts/AvatarIKController.gd
@@ -1,0 +1,232 @@
+extends Node3D
+
+# AvatarIKController receives AvatarRigFrame dictionaries from Kotlin and applies
+# lightweight humanoid IK hints to a Mixamo-style Skeleton3D.
+#
+# Expected scene setup:
+# AvatarIKController
+# └─ CoachAvatar
+#    └─ Armature
+#       └─ Skeleton3D
+#
+# Optional target nodes can be created automatically at runtime.
+
+@export var skeleton_path: NodePath = NodePath("CoachAvatar/Armature/Skeleton3D")
+@export var smoothing: float = 0.25
+@export var ik_weight: float = 0.8
+@export var ground_lock_feet: bool = true
+@export var foot_ground_y: float = 0.0
+@export var min_confidence: float = 0.35
+@export var max_rotation_step_degrees: float = 18.0
+@export var min_joint_bend_degrees: float = 4.0
+@export var max_joint_bend_degrees: float = 170.0
+@export var pole_distance: float = 0.25
+
+@onready var skeleton: Skeleton3D = get_node_or_null(skeleton_path)
+
+var _bone_directions := {}
+var _targets := {}
+var _last_left_foot_y: float = 0.0
+var _last_right_foot_y: float = 0.0
+var _last_poles := {}
+
+const MP_TO_GODOT_AXIS := Vector3(1.0, -1.0, -1.0)
+
+const CHAINS := {
+    "left_arm": {
+        "upper": "LeftArm",
+        "lower": "LeftForeArm",
+        "end": "LeftHand",
+        "target": "LeftHandIKTarget",
+        "pole": "LeftElbowPole"
+    },
+    "right_arm": {
+        "upper": "RightArm",
+        "lower": "RightForeArm",
+        "end": "RightHand",
+        "target": "RightHandIKTarget",
+        "pole": "RightElbowPole"
+    },
+    "left_leg": {
+        "upper": "LeftUpLeg",
+        "lower": "LeftLeg",
+        "end": "LeftFoot",
+        "target": "LeftFootIKTarget",
+        "pole": "LeftKneePole"
+    },
+    "right_leg": {
+        "upper": "RightUpLeg",
+        "lower": "RightLeg",
+        "end": "RightFoot",
+        "target": "RightFootIKTarget",
+        "pole": "RightKneePole"
+    }
+}
+
+func _ready() -> void:
+    if skeleton == null:
+        push_warning("AvatarIKController: Skeleton3D not found at %s" % skeleton_path)
+        return
+    _ensure_targets()
+
+func apply_avatar_rig_frame(frame: Dictionary) -> void:
+    if skeleton == null:
+        return
+    if frame.get("type", "") != "avatar_rig_frame":
+        return
+
+    _bone_directions.clear()
+    for bone_data in frame.get("bones", []):
+        var bone_name := str(bone_data.get("bone", ""))
+        var direction := bone_data.get("direction", {})
+        var confidence := float(bone_data.get("confidence", 0.0))
+        if confidence < min_confidence:
+            continue
+        var dir := Vector3(
+            float(direction.get("x", 0.0)) * MP_TO_GODOT_AXIS.x,
+            float(direction.get("y", 0.0)) * MP_TO_GODOT_AXIS.y,
+            float(direction.get("z", 0.0)) * MP_TO_GODOT_AXIS.z
+        )
+        if dir.length() <= 0.0001:
+            continue
+        _bone_directions[bone_name] = dir.normalized()
+
+    for chain_name in CHAINS.keys():
+        _apply_chain_ik(chain_name, CHAINS[chain_name])
+
+func _ensure_targets() -> void:
+    for chain_name in CHAINS.keys():
+        var chain = CHAINS[chain_name]
+        _targets[chain["target"]] = _get_or_create_marker(chain["target"])
+        _targets[chain["pole"]] = _get_or_create_marker(chain["pole"])
+
+func _get_or_create_marker(node_name: String) -> Node3D:
+    var existing := get_node_or_null(node_name)
+    if existing != null and existing is Node3D:
+        return existing
+    var marker := Node3D.new()
+    marker.name = node_name
+    add_child(marker)
+    return marker
+
+func _apply_chain_ik(chain_name: String, chain: Dictionary) -> void:
+    var upper_name: String = chain["upper"]
+    var lower_name: String = chain["lower"]
+    var end_name: String = chain["end"]
+
+    if not _bone_directions.has(upper_name) or not _bone_directions.has(lower_name):
+        return
+
+    var upper_idx := skeleton.find_bone(upper_name)
+    var lower_idx := skeleton.find_bone(lower_name)
+    var end_idx := skeleton.find_bone(end_name)
+    if upper_idx == -1 or lower_idx == -1 or end_idx == -1:
+        return
+
+    var upper_origin := skeleton.global_transform * skeleton.get_bone_global_pose(upper_idx).origin
+    var lower_origin := skeleton.global_transform * skeleton.get_bone_global_pose(lower_idx).origin
+    var end_origin := skeleton.global_transform * skeleton.get_bone_global_pose(end_idx).origin
+
+    var upper_len := max(upper_origin.distance_to(lower_origin), 0.001)
+    var lower_len := max(lower_origin.distance_to(end_origin), 0.001)
+
+    var upper_dir: Vector3 = _bone_directions[upper_name]
+    var lower_dir: Vector3 = _bone_directions[lower_name]
+    var constrained := _constrain_chain_dirs(chain_name, upper_dir, lower_dir)
+    upper_dir = constrained[0]
+    lower_dir = constrained[1]
+
+    var target_pos := upper_origin + upper_dir * upper_len + lower_dir * lower_len
+    var pole_pos := lower_origin + _compute_pole_offset(upper_dir, lower_dir, chain_name)
+
+    if ground_lock_feet and (chain_name == "left_leg" or chain_name == "right_leg"):
+        target_pos.y = _apply_foot_ground_lock(chain_name, target_pos.y)
+
+    _move_marker(chain["target"], target_pos)
+    _move_marker(chain["pole"], pole_pos)
+
+    _rotate_bone_toward(upper_idx, upper_dir, ik_weight)
+    _rotate_bone_toward(lower_idx, lower_dir, ik_weight)
+
+func _constrain_chain_dirs(chain_name: String, upper_dir: Vector3, lower_dir: Vector3) -> Array:
+    upper_dir = upper_dir.normalized()
+    lower_dir = lower_dir.normalized()
+
+    var angle := rad_to_deg(acos(clamp(upper_dir.dot(lower_dir), -1.0, 1.0)))
+    if angle < min_joint_bend_degrees:
+        lower_dir = _nudge_bend(chain_name, upper_dir, lower_dir, min_joint_bend_degrees)
+    elif angle > max_joint_bend_degrees:
+        lower_dir = _nudge_bend(chain_name, upper_dir, lower_dir, max_joint_bend_degrees)
+
+    lower_dir = _prevent_reverse_bend(chain_name, upper_dir, lower_dir)
+    return [upper_dir.normalized(), lower_dir.normalized()]
+
+func _nudge_bend(chain_name: String, upper_dir: Vector3, lower_dir: Vector3, target_degrees: float) -> Vector3:
+    var pole := _stable_pole_normal(chain_name, upper_dir, lower_dir)
+    var axis := upper_dir.cross(pole)
+    if axis.length() <= 0.0001:
+        axis = Vector3.RIGHT
+    axis = axis.normalized()
+    var q := Quaternion(axis, deg_to_rad(target_degrees))
+    return q * upper_dir
+
+func _prevent_reverse_bend(chain_name: String, upper_dir: Vector3, lower_dir: Vector3) -> Vector3:
+    var pole := _stable_pole_normal(chain_name, upper_dir, lower_dir)
+    var bend_side := upper_dir.cross(lower_dir).dot(pole)
+    if bend_side >= 0.0:
+        return lower_dir
+
+    var projected := lower_dir - pole * lower_dir.dot(pole)
+    if projected.length() <= 0.0001:
+        return _nudge_bend(chain_name, upper_dir, lower_dir, min_joint_bend_degrees)
+    return projected.normalized()
+
+func _stable_pole_normal(chain_name: String, upper_dir: Vector3, lower_dir: Vector3) -> Vector3:
+    var normal := upper_dir.cross(lower_dir)
+    if normal.length() <= 0.0001:
+        normal = _last_poles.get(chain_name, Vector3.FORWARD)
+    normal = normal.normalized()
+
+    var side := 1.0
+    if chain_name.begins_with("right"):
+        side = -1.0
+    normal *= side
+
+    var previous: Vector3 = _last_poles.get(chain_name, normal)
+    if previous.dot(normal) < 0.0:
+        normal = -normal
+    normal = previous.lerp(normal, smoothing).normalized()
+    _last_poles[chain_name] = normal
+    return normal
+
+func _compute_pole_offset(upper_dir: Vector3, lower_dir: Vector3, chain_name: String) -> Vector3:
+    return _stable_pole_normal(chain_name, upper_dir, lower_dir) * pole_distance
+
+func _apply_foot_ground_lock(chain_name: String, current_y: float) -> float:
+    var locked_y := max(current_y, foot_ground_y)
+    if chain_name == "left_leg":
+        _last_left_foot_y = lerp(_last_left_foot_y, locked_y, smoothing)
+        return _last_left_foot_y
+    _last_right_foot_y = lerp(_last_right_foot_y, locked_y, smoothing)
+    return _last_right_foot_y
+
+func _move_marker(marker_name: String, target_pos: Vector3) -> void:
+    var marker: Node3D = _targets.get(marker_name)
+    if marker == null:
+        return
+    marker.global_position = marker.global_position.lerp(target_pos, smoothing)
+
+func _rotate_bone_toward(bone_idx: int, target_dir: Vector3, weight: float) -> void:
+    if target_dir.length() <= 0.0001:
+        return
+
+    var current_q := skeleton.get_bone_pose_rotation(bone_idx)
+    var target_basis := Basis().looking_at(target_dir.normalized(), Vector3.UP)
+    var target_q := target_basis.get_rotation_quaternion()
+    var step := clamp(weight * smoothing, 0.0, 1.0)
+    var max_step := deg_to_rad(max_rotation_step_degrees)
+    var angle := current_q.angle_to(target_q)
+    if angle > max_step and angle > 0.0001:
+        step = min(step, max_step / angle)
+    var blended := current_q.slerp(target_q, step)
+    skeleton.set_bone_pose_rotation(bone_idx, blended)

--- a/app/src/main/assets/scripts/AvatarIKController.gd.remap
+++ b/app/src/main/assets/scripts/AvatarIKController.gd.remap
@@ -1,3 +1,3 @@
 [remap]
 
-path="res://scripts/AvatarIKController.gdc"
+path="res://scripts/AvatarIKController.gd"

--- a/app/src/main/assets/scripts/MixamoBoneMap.gd
+++ b/app/src/main/assets/scripts/MixamoBoneMap.gd
@@ -1,0 +1,30 @@
+extends Node
+
+const BONE_NAMES = {
+    "HIPS": "Hips",
+    "SPINE": "Spine",
+    "SPINE1": "Spine1",
+    "SPINE2": "Spine2",
+    "NECK": "Neck",
+    "HEAD": "Head",
+
+    "LEFT_SHOULDER": "LeftShoulder",
+    "LEFT_ARM": "LeftArm",
+    "LEFT_FORE_ARM": "LeftForeArm",
+    "LEFT_HAND": "LeftHand",
+
+    "RIGHT_SHOULDER": "RightShoulder",
+    "RIGHT_ARM": "RightArm",
+    "RIGHT_FORE_ARM": "RightForeArm",
+    "RIGHT_HAND": "RightHand",
+
+    "LEFT_UP_LEG": "LeftUpLeg",
+    "LEFT_LEG": "LeftLeg",
+    "LEFT_FOOT": "LeftFoot",
+    "LEFT_TOE_BASE": "LeftToeBase",
+
+    "RIGHT_UP_LEG": "RightUpLeg",
+    "RIGHT_LEG": "RightLeg",
+    "RIGHT_FOOT": "RightFoot",
+    "RIGHT_TOE_BASE": "RightToeBase"
+}

--- a/app/src/main/assets/scripts/MixamoBoneMap.gd.remap
+++ b/app/src/main/assets/scripts/MixamoBoneMap.gd.remap
@@ -1,3 +1,3 @@
 [remap]
 
-path="res://scripts/MixamoBoneMap.gdc"
+path="res://scripts/MixamoBoneMap.gd"

--- a/app/src/main/java/com/yogaflow/MainActivity.kt
+++ b/app/src/main/java/com/yogaflow/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import com.google.mediapipe.tasks.components.containers.NormalizedLandmark
 import com.yogaflow.avatar.AvatarIntent
 import com.yogaflow.coach.AvatarCoachStateMapper
 import com.yogaflow.coach.CoachCueController
@@ -158,6 +157,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
     private lateinit var godotAvatarBridge: GodotAvatarBridge
     private lateinit var llmInteractionDb: LlmInteractionDb
     private lateinit var sessionHistoryDb: SessionHistoryDb
+    private var godotSurfaceView: android.view.SurfaceView? = null
     private val demoHandler = Handler(Looper.getMainLooper())
     private val demoActions = listOf("hold_mountain", "hold_forward_fold", "hold_squat", "hold_twist")
     private var demoActionIndex = 0
@@ -194,8 +194,10 @@ class MainActivity : AppCompatActivity(), GodotHost {
             android.os.Handler(mainLooper).postDelayed({
                 val surfaceView = findSurfaceViewInHierarchy(virtualCoachView)
                 if (surfaceView != null) {
+                    godotSurfaceView = surfaceView
                     surfaceView.setZOrderOnTop(true)
                     surfaceView.holder.setFormat(android.graphics.PixelFormat.TRANSLUCENT)
+                    surfaceView.visibility = virtualCoachView.visibility
                     Log.i("YogaFlow", "Godot SurfaceView transparent configured")
                 } else {
                     Log.w("YogaFlow", "Godot SurfaceView not found")
@@ -216,7 +218,11 @@ class MainActivity : AppCompatActivity(), GodotHost {
     private val requestCameraPermission = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
-        if (granted) startCamera() else coachText.text = "Camera permission is required."
+        if (granted && cameraSetupEnabled) {
+            startCamera()
+        } else if (!granted) {
+            coachText.text = "Camera permission is required."
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -367,7 +373,6 @@ class MainActivity : AppCompatActivity(), GodotHost {
         bindSkinSelector()
         loadDiscoveredPlaylist(openClassView = false)
         applyCameraSetupEnabled(false)
-        requestCameraIfNeeded()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -532,7 +537,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
 
     private fun applyCameraSetupEnabled(enabled: Boolean) {
         cameraSetupEnabled = enabled
-        cameraToggleButton.text = "Camera"
+        cameraToggleButton.text = if (enabled) "Camera: ON" else "Camera: OFF"
         if (enabled) {
             cameraSetupController.reset()
             cameraReady = false
@@ -546,7 +551,9 @@ class MainActivity : AppCompatActivity(), GodotHost {
             updateVirtualCoachFromCurrentStep()
             cameraSetupStatus.text = "Checking body framing..."
             coachText.text = "請先完成相機設定。"
+            requestCameraIfNeeded()
         } else {
+            cameraPipeline.stop()
             cameraSetupController.reset()
             cameraReady = false
             cameraReadySince = 0L
@@ -659,7 +666,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
         isDemoMode = true
         showClass()
         overlayView.visibility = View.INVISIBLE
-        virtualCoachView.visibility = View.VISIBLE
+        setVirtualCoachVisibility(View.VISIBLE)
         startDemoCycle()
     }
 
@@ -668,7 +675,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
         overridePosition: Pair<Float, Float>?
     ) {
         runOnUiThread {
-            virtualCoachView.visibility = View.VISIBLE
+            setVirtualCoachVisibility(View.VISIBLE)
             godotAvatarBridge.send(
                 PoseCoachFrame(
                     timestampMs = System.currentTimeMillis(),
@@ -704,6 +711,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
     }
 
     internal fun requestCameraIfNeeded() {
+        if (!cameraSetupEnabled) return
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
             startCamera()
         } else {
@@ -713,23 +721,25 @@ class MainActivity : AppCompatActivity(), GodotHost {
 
     private fun handlePoseFrame(frame: PoseDetectionResult) {
         overlayView.setLandmarks(frame.imageLandmarks, frame.imageWidth, frame.imageHeight)
-        if (sessionState == SessionState.RUNNING && currentPose != null) {
-            overlayView.setJointStatus(stateMachine.getJointStatus(currentPose!!, frame))
-            overlayView.setJointCorrections(stateMachine.getJointCorrections(currentPose!!, frame))
+        if (sessionState == SessionState.RUNNING && isCurrentFlowInitialized()) {
+            overlayView.setJointStatus(stateMachine.getJointStatus(currentPose, frame))
+            overlayView.setJointCorrections(stateMachine.getJointCorrections(currentPose, frame))
         } else {
             overlayView.setJointStatus(emptyMap())
             overlayView.setJointCorrections(emptyMap())
         }
         if (isDemoMode) return
         if (!isCurrentFlowInitialized()) {
-            virtualCoachView.visibility = View.INVISIBLE
+            setVirtualCoachVisibility(View.INVISIBLE)
             return
         }
-        updateVirtualCoachBounds(frame.imageLandmarks)
         updateVirtualCoachFromCurrentStep()
 
         if (cameraSetupDisabledForDevelopment && sessionState != SessionState.COMPLETED) {
-            bypassCameraSetupForDevelopment()
+            if (sessionState != SessionState.RUNNING) {
+                markCameraReadyForDevelopment()
+                return
+            }
             liveCoachSessionController.handleReadyPoseFrame(frame, currentFlow, currentPose)
             return
         }
@@ -749,7 +759,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
         startButton.visibility = View.VISIBLE
         cameraSetupPanel.visibility = View.GONE
         overlayView.setFramingStatus(null)
-        virtualCoachView.visibility = View.VISIBLE
+        setVirtualCoachVisibility(View.VISIBLE)
         coachCueController.reset()
         sessionStartTimeMs = System.currentTimeMillis()
         sessionCorrectionCount = 0
@@ -757,8 +767,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
         updateUi(animated = false)
     }
 
-    private fun bypassCameraSetupForDevelopment() {
-        if (sessionState == SessionState.RUNNING) return
+    private fun markCameraReadyForDevelopment() {
         cameraReady = true
         cameraReadySince = System.currentTimeMillis()
         autoStartedCurrentSetup = true
@@ -766,12 +775,8 @@ class MainActivity : AppCompatActivity(), GodotHost {
         startButton.alpha = 1f
         startButton.visibility = View.VISIBLE
         cameraSetupPanel.visibility = View.GONE
-        virtualCoachView.visibility = View.VISIBLE
-        sessionState = SessionState.RUNNING
-        coachCueController.reset()
-        sessionStartTimeMs = System.currentTimeMillis()
-        sessionCorrectionCount = 0
-        sessionStepsCompleted = 0
+        updateVirtualCoachFromCurrentStep()
+        coachText.text = "Development: camera setup bypassed. Tap Start to begin."
         updateUi(animated = false)
     }
 
@@ -793,7 +798,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
         for ((delay, action) in steps) {
             handler.postDelayed({
                 android.util.Log.i("YogaFlow", "AvatarSelfTest: sending $action")
-                virtualCoachView.visibility = android.view.View.VISIBLE
+                setVirtualCoachVisibility(android.view.View.VISIBLE)
                 godotAvatarBridge.send(buildSelfTestFrame(action), force = true)
             }, delay)
         }
@@ -826,7 +831,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
                 if (!isDemoMode) return
                 val action = demoActions[demoActionIndex % demoActions.size]
                 demoActionIndex += 1
-                virtualCoachView.visibility = View.VISIBLE
+                setVirtualCoachVisibility(View.VISIBLE)
                 godotAvatarBridge.send(buildSelfTestFrame(action), force = true)
                 demoHandler.postDelayed(this, 3000L)
             }
@@ -877,7 +882,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
         if (next == null) {
             sessionState = SessionState.COMPLETED
             coachText.text = text
-            virtualCoachView.visibility = View.INVISIBLE
+            setVirtualCoachVisibility(View.INVISIBLE)
             updateUi(animated = true)
             showCompletionOverlay()
             return
@@ -1123,14 +1128,14 @@ class MainActivity : AppCompatActivity(), GodotHost {
         val shouldShowCoach = detect.isNotBlank() &&
             state != CoachState.SETUP &&
             sessionState != SessionState.COMPLETED
-        virtualCoachView.visibility = if (shouldShowCoach) View.VISIBLE else View.INVISIBLE
+        setVirtualCoachVisibility(if (shouldShowCoach) View.VISIBLE else View.INVISIBLE)
     }
 
     private fun updateVirtualCoach(frame: PoseCoachFrame) {
         val shouldShowCoach = frame.stepId.isNotBlank() &&
             frame.avatar.action.isNotBlank() &&
             sessionState != SessionState.COMPLETED
-        virtualCoachView.visibility = if (shouldShowCoach) View.VISIBLE else View.INVISIBLE
+        setVirtualCoachVisibility(if (shouldShowCoach) View.VISIBLE else View.INVISIBLE)
     }
 
     private fun buildPoseCoachFrame(
@@ -1211,23 +1216,22 @@ class MainActivity : AppCompatActivity(), GodotHost {
         return if (isEmpty()) null else average()
     }
 
-    private fun updateVirtualCoachBounds(landmarks: List<NormalizedLandmark>) {
-        // Full-screen fusion: Godot handles its own layout
-    }
-
-    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
-
     fun updateVirtualCoachFromCurrentStep() {
         if (!isCurrentFlowInitialized()) {
-            virtualCoachView.visibility = View.INVISIBLE
+            setVirtualCoachVisibility(View.INVISIBLE)
             return
         }
         val step = currentFlow.steps.getOrNull(flowEngine.currentStepNumber() - 1)
         if (step == null || sessionState == SessionState.COMPLETED) {
-            virtualCoachView.visibility = View.INVISIBLE
+            setVirtualCoachVisibility(View.INVISIBLE)
             return
         }
         updateVirtualCoach(step.detect.jsonKey, step.state)
+    }
+
+    private fun setVirtualCoachVisibility(visibility: Int) {
+        virtualCoachView.visibility = visibility
+        godotSurfaceView?.visibility = visibility
     }
 
     private fun toggleSessionRecording() {
@@ -1290,9 +1294,6 @@ class MainActivity : AppCompatActivity(), GodotHost {
     companion object {
         const val TUNING_SLIDER_MAX = 1000
         private const val CAMERA_AUTO_START_STABLE_MS = 600L
-        private const val VIRTUAL_COACH_ASPECT_RATIO = 0.72f
-        private const val VIRTUAL_COACH_HEIGHT_SCALE = 1.35f
-        private const val VIRTUAL_COACH_MAX_HEIGHT_FRACTION = 0.68f
         private const val DEV_PREFS = "development"
         private const val PREF_DISABLE_CAMERA_SETUP = "disableCameraSetup"
         private const val EXTRA_DISABLE_CAMERA_SETUP = "devDisableCameraSetup"
@@ -1302,6 +1303,5 @@ class MainActivity : AppCompatActivity(), GodotHost {
         private const val EXTRA_AVATAR_TARGET_X = "avatarTargetX"
         private const val EXTRA_AVATAR_TARGET_Y = "avatarTargetY"
         private const val EXTRA_AVATAR_CLEAR_OVERRIDE = "avatarClearOverride"
-        private val VIRTUAL_COACH_SCALE_INDICES = listOf(0, 11, 12, 23, 24, 25, 26, 27, 28)
     }
 }

--- a/app/src/main/java/com/yogaflow/MainActivityPlaylist.kt
+++ b/app/src/main/java/com/yogaflow/MainActivityPlaylist.kt
@@ -66,28 +66,31 @@ internal fun MainActivity.restartCurrentPlaylist() {
 
 internal fun MainActivity.resetToCameraSetup(message: String) {
     resetCameraSetupController()
+    val bypassReady = cameraSetupEnabled && cameraSetupDisabledForDevelopment
     sessionState = SessionState.IDLE
-    cameraReady = cameraSetupDisabledForDevelopment
-    cameraReadySince = if (cameraSetupDisabledForDevelopment) System.currentTimeMillis() else 0L
-    autoStartedCurrentSetup = cameraSetupDisabledForDevelopment
-    startButton.isEnabled = cameraSetupDisabledForDevelopment
-    startButton.alpha = if (cameraSetupDisabledForDevelopment) 1f else 0.45f
-    startButton.visibility = android.view.View.GONE
-    beginSessionButton.isEnabled = false
-    beginSessionButton.alpha = 0.45f
-    cameraSetupPanel.visibility = if (cameraSetupDisabledForDevelopment) {
-        android.view.View.GONE
-    } else {
+    cameraReady = bypassReady
+    cameraReadySince = if (bypassReady) System.currentTimeMillis() else 0L
+    autoStartedCurrentSetup = bypassReady
+    startButton.isEnabled = bypassReady
+    startButton.alpha = if (bypassReady) 1f else 0.45f
+    startButton.visibility = android.view.View.VISIBLE
+    beginSessionButton.isEnabled = bypassReady
+    beginSessionButton.alpha = if (bypassReady) 1f else 0.45f
+    cameraSetupPanel.visibility = if (cameraSetupEnabled && !bypassReady) {
         android.view.View.VISIBLE
+    } else {
+        android.view.View.GONE
     }
     updateVirtualCoachFromCurrentStep()
-    cameraSetupStatus.text = if (cameraSetupDisabledForDevelopment) {
+    cameraSetupStatus.text = if (bypassReady) {
         "Development: camera setup bypassed"
     } else {
         "Checking body framing..."
     }
     lastCountdownText = ""
-    coachText.text = if (cameraSetupDisabledForDevelopment) {
+    coachText.text = if (!cameraSetupEnabled) {
+        "Camera setup is off. Tap Camera to enable."
+    } else if (bypassReady) {
         "Development: camera setup bypassed."
     } else {
         message

--- a/app/src/main/java/com/yogaflow/MainActivityUi.kt
+++ b/app/src/main/java/com/yogaflow/MainActivityUi.kt
@@ -68,10 +68,10 @@ internal fun MainActivity.showHome() {
 internal fun MainActivity.showClass() {
     homeView.visibility = View.GONE
     classView.visibility = View.VISIBLE
-    classView.post { requestCameraIfNeeded() }
 }
 
 internal fun MainActivity.startCamera() {
     if (classView.visibility != View.VISIBLE || homeView.visibility == View.VISIBLE) return
+    if (!cameraSetupEnabled) return
     cameraPipeline.start()
 }

--- a/app/src/main/java/com/yogaflow/coach/PoseDetectionRouter.kt
+++ b/app/src/main/java/com/yogaflow/coach/PoseDetectionRouter.kt
@@ -39,17 +39,29 @@ class PoseDetectionRouter(
                 val r = bridgeDetectionMapper.evaluate(detect, frame, params)
                 PoseDetectionMappingResult(r.matched, r.state, r.cue, if (!r.matched) r.reason else "")
             }
-            "mountain" -> {
-                val (state, cue) = fallback.update(currentPose, frame)
-                val matched = state != CoachState.CORRECTION
-                PoseDetectionMappingResult(
-                    matched = matched,
-                    state = if (matched) expectedState else state,
-                    cue = cue,
-                    reason = if (!matched) cue else ""
-                )
-            }
+            "mountain",
+            "warrior_1",
+            "warrior_2",
+            "downward_dog",
+            "child_pose",
+            "pigeon" -> fallbackMapping(fallback, currentPose, frame, expectedState)
             else -> error("No detection mapper registered for poseId=$poseId detect=${detect.jsonKey}")
         }
+    }
+
+    private fun fallbackMapping(
+        fallback: PoseStateMachine,
+        currentPose: YogaPose,
+        frame: PoseDetectionResult,
+        expectedState: CoachState
+    ): PoseDetectionMappingResult {
+        val (state, cue) = fallback.update(currentPose, frame)
+        val matched = state != CoachState.CORRECTION
+        return PoseDetectionMappingResult(
+            matched = matched,
+            state = if (matched) expectedState else state,
+            cue = cue,
+            reason = if (!matched) cue else ""
+        )
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -69,8 +69,11 @@
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/virtualCoachView"
             android:name="org.godotengine.godot.GodotFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="110dp"
+            android:layout_height="196dp"
+            android:layout_gravity="bottom|end"
+            android:layout_marginEnd="12dp"
+            android:layout_marginBottom="88dp"
             android:visibility="invisible" />
 
         <TextView

--- a/app/src/test/java/com/yogaflow/avatar/AvatarLayoutContractTest.kt
+++ b/app/src/test/java/com/yogaflow/avatar/AvatarLayoutContractTest.kt
@@ -1,0 +1,22 @@
+package com.yogaflow.avatar
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class AvatarLayoutContractTest {
+
+    @Test
+    fun virtualCoachView_isCornerPipNotFullscreen() {
+        val layout = File("src/main/res/layout/activity_main.xml").readText()
+        val virtualCoachBlock = Regex(
+            """<androidx\.fragment\.app\.FragmentContainerView[\s\S]*?android:id="@\+id/virtualCoachView"[\s\S]*?/>"""
+        ).find(layout)?.value ?: error("virtualCoachView not found")
+
+        assertTrue(virtualCoachBlock.contains("""android:layout_width="110dp""""))
+        assertTrue(virtualCoachBlock.contains("""android:layout_height="196dp""""))
+        assertTrue(virtualCoachBlock.contains("""android:layout_gravity="bottom|end""""))
+        assertTrue(!virtualCoachBlock.contains("""android:layout_width="match_parent""""))
+        assertTrue(!virtualCoachBlock.contains("""android:layout_height="match_parent""""))
+    }
+}

--- a/app/src/test/java/com/yogaflow/avatar/GodotScriptAssetSyncTest.kt
+++ b/app/src/test/java/com/yogaflow/avatar/GodotScriptAssetSyncTest.kt
@@ -1,0 +1,29 @@
+package com.yogaflow.avatar
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class GodotScriptAssetSyncTest {
+
+    @Test
+    fun godotScripts_areMirroredIntoAppAssets() {
+        val repoRoot = File("..").canonicalFile
+        val godotScripts = File(repoRoot, "godot/scripts")
+            .listFiles { file -> file.extension == "gd" }
+            ?.sortedBy { it.name }
+            .orEmpty()
+
+        assertTrue("Expected Godot script sources", godotScripts.isNotEmpty())
+        godotScripts.forEach { godotScript ->
+            val assetScript = File(repoRoot, "app/src/main/assets/scripts/${godotScript.name}")
+            assertTrue("Missing app asset script ${assetScript.path}", assetScript.isFile)
+            assertEquals(
+                "Script source differs for ${godotScript.name}",
+                godotScript.readText(),
+                assetScript.readText()
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/yogaflow/coach/PoseDetectionRouterTest.kt
+++ b/app/src/test/java/com/yogaflow/coach/PoseDetectionRouterTest.kt
@@ -1,0 +1,42 @@
+package com.yogaflow.coach
+
+import com.yogaflow.flow.FlowParser
+import com.yogaflow.pose.PoseDetectionResult
+import com.yogaflow.yoga.YogaPoseCatalog
+import org.junit.Test
+import java.io.File
+
+class PoseDetectionRouterTest {
+
+    @Test
+    fun evaluate_allPackagedFlowSteps_doesNotThrowForCatalogPoseIds() {
+        val router = PoseDetectionRouter()
+        val fallback = PoseStateMachine()
+        val emptyFrame = PoseDetectionResult(imageLandmarks = emptyList())
+        val posesById = YogaPoseCatalog.poses.associateBy { it.id }
+        val flowFiles = File("src/main/assets/flows")
+            .listFiles { file -> file.extension == "json" && file.name.endsWith(".flow.json") }
+            ?.sortedBy { it.name }
+            .orEmpty()
+
+        flowFiles.forEach { file ->
+            val flow = FlowParser.parse(file.readText())
+            val pose = posesById[flow.pose]
+                ?: error("Flow ${flow.id} uses pose ${flow.pose}, but it is missing from YogaPoseCatalog")
+
+            flow.steps.forEachIndexed { index, step ->
+                runCatching {
+                    router.evaluate(
+                        poseId = flow.pose,
+                        detect = step.detect,
+                        params = step.params,
+                        frame = emptyFrame,
+                        fallback = fallback,
+                        currentPose = pose,
+                        expectedState = step.state
+                    )
+                }.getOrElse { error("Router failed for ${file.name} step ${index + 1}: ${it.message}") }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/yogaflow/flow/FlowParserTest.kt
+++ b/app/src/test/java/com/yogaflow/flow/FlowParserTest.kt
@@ -20,4 +20,24 @@ class FlowParserTest {
             assertTrue(step.durationMs > 0)
         }
     }
+
+    @Test
+    fun parse_allPackagedFlows_returnsValidFlowShapes() {
+        val flowFiles = File("src/main/assets/flows")
+            .listFiles { file -> file.extension == "json" && file.name.endsWith(".flow.json") }
+            ?.sortedBy { it.name }
+            .orEmpty()
+
+        assertTrue("Expected packaged flow assets", flowFiles.isNotEmpty())
+        flowFiles.forEach { file ->
+            val flow = FlowParser.parse(file.readText())
+
+            assertFalse("Flow id is blank in ${file.name}", flow.id.isBlank())
+            assertTrue("No steps in ${file.name}", flow.steps.isNotEmpty())
+            flow.steps.forEach { step ->
+                assertFalse("Blank cue in ${file.name}", step.cue.isBlank())
+                assertTrue("Invalid duration in ${file.name}", step.durationMs > 0)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #112.
Fixes #113.
Fixes #114.
Fixes #115.

- route all packaged flow poses, including flows 16-20, without crashing
- restore the Godot avatar to the documented 110dp x 196dp bottom-end PiP layout
- make `Camera: OFF/ON` gate the CameraX lifecycle and preserve the manual Start gate, including when the dev camera-setup bypass preference is present
- mirror missing Godot `.gd` sources into app assets and point remaps at `.gd` sources
- add regression tests for packaged flows, router coverage, avatar layout, and GDScript source sync

## Verification
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew test assembleDebug --console=plain`
- `adb install -r app/build/outputs/apk/debug/app-debug.apk`
- `adb shell am start -n com.yogaflow/.MainActivity`
- Screenshot `session-recordings/screencap-20260511-221111.png`: class screen with `Camera: OFF`, idle black preview, disabled Start, and no camera feed/skeleton/avatar.
- Screenshot `session-recordings/screencap-20260511-221322.png`: class screen with `Camera: ON`, live camera feed, skeleton overlay, and no avatar before pressing Start.
- `adb logcat -d | grep -E "Yoga|Godot|MediaPipe|AndroidRuntime" | tail -40` showed Godot initialization and bridge connection for the fresh launch; older pre-existing `F DEBUG` Godot entries remain in device log history from earlier runs.
