### PR TITLE
Add avatar skin profiles, preferred avatar action override, and flow parsing for `avatar_action`

### DIFF
--- a/app/src/main/assets/scripts/AvatarController.gd
+++ b/app/src/main/assets/scripts/AvatarController.gd
@@ -16,6 +16,9 @@ var _override_x: float = 0.0
 var _override_y: float = 0.0
 var _override_x_gain: float = 3.0
 
+var _skin_profiles: Dictionary = {}
+var _default_skin: String = "classic"
+
 var _semantic_offsets := {
     "left_side": Vector3(-1.45, 0.0, 0.0),
     "right_side": Vector3(1.45, 0.0, 0.0),
@@ -34,6 +37,7 @@ func _ready() -> void:
     _base_rotation = avatar_node.rotation
     _base_scale = avatar_node.scale
     _setup_animations()
+    _load_skin_profiles()
 
 func _setup_animations() -> void:
     if animation_player == null:
@@ -129,17 +133,43 @@ func set_override_position(world_x: float, world_y: float) -> void:
 func clear_override_position() -> void:
     _override_active = false
 
+func _load_skin_profiles() -> void:
+    var file := FileAccess.open("res://skins/skin_profiles.json", FileAccess.READ)
+    if file == null:
+        push_warning("AvatarController: missing res://skins/skin_profiles.json, using built-in defaults")
+        _skin_profiles = {
+            "classic": {"key_light": [1.0, 1.0, 1.0], "fill_light": [1.0, 0.8, 0.5]},
+            "nature": {"key_light": [0.75, 1.0, 0.65], "fill_light": [0.55, 0.85, 0.45]},
+            "ocean": {"key_light": [0.65, 0.82, 1.0], "fill_light": [0.45, 0.65, 1.0]}
+        }
+        _default_skin = "classic"
+        return
+
+    var parsed = JSON.parse_string(file.get_as_text())
+    if typeof(parsed) != TYPE_DICTIONARY:
+        push_warning("AvatarController: invalid skin_profiles.json format, using built-in defaults")
+        _skin_profiles = {
+            "classic": {"key_light": [1.0, 1.0, 1.0], "fill_light": [1.0, 0.8, 0.5]},
+            "nature": {"key_light": [0.75, 1.0, 0.65], "fill_light": [0.55, 0.85, 0.45]},
+            "ocean": {"key_light": [0.65, 0.82, 1.0], "fill_light": [0.45, 0.65, 1.0]}
+        }
+        _default_skin = "classic"
+        return
+
+    _default_skin = str(parsed.get("default", "classic"))
+    _skin_profiles = parsed.get("skins", {})
+
 func apply_skin(skin_name: String) -> void:
-    match skin_name:
-        "nature":
-            key_light.light_color = Color(0.75, 1.0, 0.65)
-            fill_light.light_color = Color(0.55, 0.85, 0.45)
-        "ocean":
-            key_light.light_color = Color(0.65, 0.82, 1.0)
-            fill_light.light_color = Color(0.45, 0.65, 1.0)
-        _:
-            key_light.light_color = Color.WHITE
-            fill_light.light_color = Color(1.0, 0.80, 0.50)
+    var selected_name = skin_name
+    if !_skin_profiles.has(selected_name):
+        selected_name = _default_skin
+
+    var selected = _skin_profiles.get(selected_name, {})
+    var key = selected.get("key_light", [1.0, 1.0, 1.0])
+    var fill = selected.get("fill_light", [1.0, 0.8, 0.5])
+
+    key_light.light_color = Color(float(key[0]), float(key[1]), float(key[2]))
+    fill_light.light_color = Color(float(fill[0]), float(fill[1]), float(fill[2]))
 
 func apply_pose_metrics(pose: Dictionary) -> void:
     if skeleton == null:

--- a/app/src/main/assets/skins/skin_profiles.json
+++ b/app/src/main/assets/skins/skin_profiles.json
@@ -1,0 +1,17 @@
+{
+  "default": "classic",
+  "skins": {
+    "classic": {
+      "key_light": [1.0, 1.0, 1.0],
+      "fill_light": [1.0, 0.8, 0.5]
+    },
+    "nature": {
+      "key_light": [0.75, 1.0, 0.65],
+      "fill_light": [0.55, 0.85, 0.45]
+    },
+    "ocean": {
+      "key_light": [0.65, 0.82, 1.0],
+      "fill_light": [0.45, 0.65, 1.0]
+    }
+  }
+}

--- a/app/src/main/java/com/yogaflow/MainActivity.kt
+++ b/app/src/main/java/com/yogaflow/MainActivity.kt
@@ -1153,6 +1153,7 @@ class MainActivity : AppCompatActivity(), GodotHost {
             matched = matched,
             failReason = failReason,
             poseId = currentPose.id,
+            preferredAction = step?.avatarAction,
             overridePosition = avatarPositionOverride
         )
         return PoseCoachFrame(

--- a/app/src/main/java/com/yogaflow/coach/AvatarCoachStateMapper.kt
+++ b/app/src/main/java/com/yogaflow/coach/AvatarCoachStateMapper.kt
@@ -9,10 +9,11 @@ class AvatarCoachStateMapper {
         matched: Boolean,
         failReason: String,
         poseId: String?,
+        preferredAction: String? = null,
         overridePosition: Pair<Float, Float>? = null
     ): AvatarIntent {
         val highlight = highlightFor(detect, failReason)
-        val action = when {
+        val derivedAction = when {
             state == CoachState.CORRECTION && highlight == "knees" -> "correct_knees"
             state == CoachState.CORRECTION && highlight == "hips" -> "correct_hips"
             state == CoachState.CORRECTION && highlight == "spine" -> "correct_spine"
@@ -23,6 +24,11 @@ class AvatarCoachStateMapper {
             poseId == "bridge" -> "hold_bridge"
             state == CoachState.TRANSITION -> "controlled_transition"
             else -> "hold_mountain"
+        }
+        val preferred = preferredAction?.trim()?.takeIf { it.isNotEmpty() }
+        val action = when {
+            state == CoachState.CORRECTION -> derivedAction
+            else -> preferred ?: derivedAction
         }
         val emotion = when {
             state == CoachState.CORRECTION || !matched -> "focused"

--- a/app/src/main/java/com/yogaflow/flow/FlowJsonValidator.kt
+++ b/app/src/main/java/com/yogaflow/flow/FlowJsonValidator.kt
@@ -67,6 +67,9 @@ object FlowJsonValidator {
         if (step.has("correction") && !isString(step, "correction")) {
             error("Invalid Flow JSON: $path.correction must be a string")
         }
+        if (step.has("avatar_action") && !isString(step, "avatar_action")) {
+            error("Invalid Flow JSON: $path.avatar_action must be a string")
+        }
 
         if (step.has("runtime")) {
             val runtime = step.optJSONObject("runtime")

--- a/app/src/main/java/com/yogaflow/flow/FlowParser.kt
+++ b/app/src/main/java/com/yogaflow/flow/FlowParser.kt
@@ -40,6 +40,7 @@ object FlowParser {
             cue = step.getString("cue"),
             detect = DetectKey.fromJsonKey(step.getString("detect")),
             correction = step.optString("correction", ""),
+            avatarAction = step.optString("avatar_action", "").ifBlank { null },
             params = params
         )
     }

--- a/app/src/main/java/com/yogaflow/flow/YogaFlow.kt
+++ b/app/src/main/java/com/yogaflow/flow/YogaFlow.kt
@@ -18,5 +18,6 @@ data class YogaFlowStep(
     val cue: String,
     val detect: DetectKey,
     val correction: String,
+    val avatarAction: String? = null,
     val params: RuntimeParams = RuntimeParams.EMPTY
 )

--- a/app/src/test/java/com/yogaflow/coach/AvatarCoachStateMapperTest.kt
+++ b/app/src/test/java/com/yogaflow/coach/AvatarCoachStateMapperTest.kt
@@ -1,0 +1,37 @@
+package com.yogaflow.coach
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AvatarCoachStateMapperTest {
+
+    private val mapper = AvatarCoachStateMapper()
+
+    @Test
+    fun map_usesPreferredAction_whenNotCorrection() {
+        val intent = mapper.map(
+            detect = "mountain_hold",
+            state = CoachState.HOLD,
+            matched = true,
+            failReason = "",
+            poseId = "mountain",
+            preferredAction = "hold_warrior_1"
+        )
+
+        assertEquals("hold_warrior_1", intent.action)
+    }
+
+    @Test
+    fun map_ignoresPreferredAction_whenCorrection() {
+        val intent = mapper.map(
+            detect = "squat_hold",
+            state = CoachState.CORRECTION,
+            matched = false,
+            failReason = "knee angle too low",
+            poseId = "squat",
+            preferredAction = "hold_warrior_1"
+        )
+
+        assertEquals("correct_knees", intent.action)
+    }
+}

--- a/app/src/test/java/com/yogaflow/flow/FlowParserTest.kt
+++ b/app/src/test/java/com/yogaflow/flow/FlowParserTest.kt
@@ -40,4 +40,33 @@ class FlowParserTest {
             }
         }
     }
+    @Test
+    fun parse_avatarActionField_mapsIntoStep() {
+        val text = """
+            {
+              "flow": {
+                "id": "test_flow",
+                "name": "Test",
+                "pose": "mountain",
+                "language": "zh-TW",
+                "level": "beginner"
+              },
+              "steps": [
+                {
+                  "state": "HOLD",
+                  "durationMs": 1500,
+                  "cue": "測試",
+                  "detect": "mountain_hold",
+                  "avatar_action": "hold_mountain"
+                }
+              ],
+              "end": {"cue": "done"}
+            }
+        """.trimIndent()
+
+        val flow = FlowParser.parse(text)
+
+        assertTrue(flow.steps.first().avatarAction == "hold_mountain")
+    }
+
 }

--- a/godot/scripts/AvatarController.gd
+++ b/godot/scripts/AvatarController.gd
@@ -16,6 +16,9 @@ var _override_x: float = 0.0
 var _override_y: float = 0.0
 var _override_x_gain: float = 3.0
 
+var _skin_profiles: Dictionary = {}
+var _default_skin: String = "classic"
+
 var _semantic_offsets := {
     "left_side": Vector3(-1.45, 0.0, 0.0),
     "right_side": Vector3(1.45, 0.0, 0.0),
@@ -34,6 +37,7 @@ func _ready() -> void:
     _base_rotation = avatar_node.rotation
     _base_scale = avatar_node.scale
     _setup_animations()
+    _load_skin_profiles()
 
 func _setup_animations() -> void:
     if animation_player == null:
@@ -129,17 +133,43 @@ func set_override_position(world_x: float, world_y: float) -> void:
 func clear_override_position() -> void:
     _override_active = false
 
+func _load_skin_profiles() -> void:
+    var file := FileAccess.open("res://skins/skin_profiles.json", FileAccess.READ)
+    if file == null:
+        push_warning("AvatarController: missing res://skins/skin_profiles.json, using built-in defaults")
+        _skin_profiles = {
+            "classic": {"key_light": [1.0, 1.0, 1.0], "fill_light": [1.0, 0.8, 0.5]},
+            "nature": {"key_light": [0.75, 1.0, 0.65], "fill_light": [0.55, 0.85, 0.45]},
+            "ocean": {"key_light": [0.65, 0.82, 1.0], "fill_light": [0.45, 0.65, 1.0]}
+        }
+        _default_skin = "classic"
+        return
+
+    var parsed = JSON.parse_string(file.get_as_text())
+    if typeof(parsed) != TYPE_DICTIONARY:
+        push_warning("AvatarController: invalid skin_profiles.json format, using built-in defaults")
+        _skin_profiles = {
+            "classic": {"key_light": [1.0, 1.0, 1.0], "fill_light": [1.0, 0.8, 0.5]},
+            "nature": {"key_light": [0.75, 1.0, 0.65], "fill_light": [0.55, 0.85, 0.45]},
+            "ocean": {"key_light": [0.65, 0.82, 1.0], "fill_light": [0.45, 0.65, 1.0]}
+        }
+        _default_skin = "classic"
+        return
+
+    _default_skin = str(parsed.get("default", "classic"))
+    _skin_profiles = parsed.get("skins", {})
+
 func apply_skin(skin_name: String) -> void:
-    match skin_name:
-        "nature":
-            key_light.light_color = Color(0.75, 1.0, 0.65)
-            fill_light.light_color = Color(0.55, 0.85, 0.45)
-        "ocean":
-            key_light.light_color = Color(0.65, 0.82, 1.0)
-            fill_light.light_color = Color(0.45, 0.65, 1.0)
-        _:
-            key_light.light_color = Color.WHITE
-            fill_light.light_color = Color(1.0, 0.80, 0.50)
+    var selected_name = skin_name
+    if !_skin_profiles.has(selected_name):
+        selected_name = _default_skin
+
+    var selected = _skin_profiles.get(selected_name, {})
+    var key = selected.get("key_light", [1.0, 1.0, 1.0])
+    var fill = selected.get("fill_light", [1.0, 0.8, 0.5])
+
+    key_light.light_color = Color(float(key[0]), float(key[1]), float(key[2]))
+    fill_light.light_color = Color(float(fill[0]), float(fill[1]), float(fill[2]))
 
 func apply_pose_metrics(pose: Dictionary) -> void:
     if skeleton == null:

--- a/godot/skins/skin_profiles.json
+++ b/godot/skins/skin_profiles.json
@@ -1,0 +1,17 @@
+{
+  "default": "classic",
+  "skins": {
+    "classic": {
+      "key_light": [1.0, 1.0, 1.0],
+      "fill_light": [1.0, 0.8, 0.5]
+    },
+    "nature": {
+      "key_light": [0.75, 1.0, 0.65],
+      "fill_light": [0.55, 0.85, 0.45]
+    },
+    "ocean": {
+      "key_light": [0.65, 0.82, 1.0],
+      "fill_light": [0.45, 0.65, 1.0]
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide configurable visual skin profiles for the avatar and allow runtime selection from JSON rather than hard-coded colors. 
- Allow flows to specify a preferred avatar action and have the system honor that preference unless the coach is in a correction state. 
- Ensure flow JSON validation and parsing support the new `avatar_action` field.

### Description
- Added skin profile support to the avatar controller by introducing `_load_skin_profiles()` and `_skin_profiles` with fallback defaults, and moved `apply_skin()` to select colors from the parsed profiles instead of hard-coded matches in `AvatarController.gd` (both `app` and `godot` script locations). 
- Added `skins/skin_profiles.json` assets under both `app/src/main/assets/skins` and `godot/skins` containing default `classic`, `nature`, and `ocean` profiles and a `default` key. 
- Threaded a `preferredAction` through from `MainActivity.buildPoseCoachFrame()` into `AvatarCoachStateMapper.map()` so flows can request a preferred avatar action via the frame. 
- Extended `AvatarCoachStateMapper` to accept `preferredAction` and use it for non-correction states while preserving explicit correction-derived actions. 
- Updated flow parsing and models to support `avatar_action` by adding validation in `FlowJsonValidator`, parsing in `FlowParser` into `YogaFlowStep.avatarAction`, and adding the new property to `YogaFlowStep` in `YogaFlow.kt`. 
- Added unit tests: `AvatarCoachStateMapperTest` to verify preferred-action behavior, and a `FlowParserTest` case to confirm `avatar_action` maps into parsed steps.

### Testing
- Ran unit tests including `AvatarCoachStateMapperTest` and updated `FlowParserTest`; the new tests validate that preferred actions are used when not in correction and ignored during correction, and that `avatar_action` is parsed into a `YogaFlowStep`, and they passed. 
- Ran the existing packaged flow parsing tests (`parse_allPackagedFlows_returnsValidFlowShapes`) to confirm no regressions in flow parsing, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f55bb2a8832eae1f5c07f6add5c0)